### PR TITLE
Build real offline PDF Pro tools

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -1,6 +1,8 @@
 name: Android Build
 
 on:
+  push:
+    branches: [feat/pdf-pro-tools]
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -1,0 +1,41 @@
+name: Android Build
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  android-debug:
+    runs-on: ubuntu-latest
+    env:
+      CI: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: gradle
+      - name: Install dependencies
+        run: npm ci
+      - name: Generate Android project
+        run: npx expo prebuild --platform android --clean
+      - name: Build debug APK
+        run: |
+          cd android
+          chmod +x gradlew
+          ./gradlew assembleDebug --no-daemon
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: pdf-pro-debug-apk
+          path: android/app/build/outputs/apk/debug/app-debug.apk
+          if-no-files-found: error

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -21,11 +21,10 @@ jobs:
           node-version: 24
           cache: npm
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
-          cache: gradle
       - name: Install dependencies
         run: npm ci
       - name: Generate Android project

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -55,19 +55,21 @@ jobs:
         run: npm run typecheck
 
       - name: Generate Android project
-        run: npx expo prebuild --platform android --clean --non-interactive
+        run: npx expo prebuild --platform android --clean
 
-      - name: Build installable debug APK
+      - name: Build standalone release APK
         working-directory: android
+        env:
+          NODE_ENV: production
         run: |
           chmod +x gradlew
-          ./gradlew assembleDebug --no-daemon
+          ./gradlew assembleRelease --no-daemon
 
       - name: Verify APK package, signature and archive
         shell: bash
         run: |
           set -euo pipefail
-          APK="$(find android/app/build/outputs/apk/debug -maxdepth 1 -type f -name '*.apk' | head -n 1)"
+          APK="$(find android/app/build/outputs/apk/release -maxdepth 1 -type f -name '*.apk' | head -n 1)"
           test -n "$APK"
           cp "$APK" release-output/PDF-Pro-Tools-1.2.0.apk
 
@@ -98,7 +100,7 @@ jobs:
           version=1.2.0
           versionCode=3
           androidPackage=com.codecsverige.pdf
-          build=debug-install-test
+          build=standalone-release
           validation=signature+archive+badging+emulator-install-launch
           EOF
 

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -129,7 +129,7 @@ jobs:
           emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script: |
-            set -euo pipefail
+            set -eu
             adb devices -l | tee release-output/adb-devices.txt
             adb shell getprop sys.boot_completed | tee release-output/boot-completed.txt
 

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -1,42 +1,167 @@
-name: Android Build
+name: Build and Validate PDF Pro APK
 
 on:
   push:
     branches: [feat/pdf-pro-tools]
+    paths:
+      - 'App.tsx'
+      - 'app.json'
+      - 'index.ts'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'services/**'
+      - 'assets/**'
+      - '.github/workflows/android-build.yml'
   pull_request:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: pdf-pro-android-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  android-debug:
+  android-apk:
     runs-on: ubuntu-latest
+    timeout-minutes: 50
     env:
       CI: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: '20'
           cache: npm
-      - name: Setup Java
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: 17
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Prepare validation output
+        run: mkdir -p release-output
+
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --no-audit --no-fund
+
+      - name: TypeScript validation
+        run: npm run typecheck
+
       - name: Generate Android project
-        run: npx expo prebuild --platform android --clean
-      - name: Build debug APK
+        run: npx expo prebuild --platform android --clean --non-interactive
+
+      - name: Build installable debug APK
+        working-directory: android
         run: |
-          cd android
           chmod +x gradlew
           ./gradlew assembleDebug --no-daemon
-      - name: Upload APK
+
+      - name: Verify APK package, signature and archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          APK="$(find android/app/build/outputs/apk/debug -maxdepth 1 -type f -name '*.apk' | head -n 1)"
+          test -n "$APK"
+          cp "$APK" release-output/PDF-Pro-Tools-1.2.0.apk
+
+          BUILD_TOOLS="$(find "$ANDROID_HOME/build-tools" -mindepth 1 -maxdepth 1 -type d | sort -V | tail -n 1)"
+          "$BUILD_TOOLS/apksigner" verify --verbose --print-certs release-output/PDF-Pro-Tools-1.2.0.apk | tee release-output/signature-verification.txt
+          sha256sum release-output/PDF-Pro-Tools-1.2.0.apk | tee release-output/PDF-Pro-Tools-1.2.0.sha256
+          unzip -t release-output/PDF-Pro-Tools-1.2.0.apk > release-output/zip-integrity.txt
+          "$BUILD_TOOLS/aapt" dump badging release-output/PDF-Pro-Tools-1.2.0.apk > release-output/apk-badging-full.txt
+
+          grep -q "package: name='com.codecsverige.pdf'" release-output/apk-badging-full.txt
+          grep -q "versionCode='3'" release-output/apk-badging-full.txt
+          grep -q "versionName='1.2.0'" release-output/apk-badging-full.txt
+
+          python3 - <<'PY'
+          import zipfile
+          path = 'release-output/PDF-Pro-Tools-1.2.0.apk'
+          with zipfile.ZipFile(path) as z:
+              names = z.namelist()
+              abis = sorted({name.split('/')[1] for name in names if name.startswith('lib/') and name.count('/') >= 2})
+              assert 'AndroidManifest.xml' in names
+              assert 'classes.dex' in names
+              assert 'arm64-v8a' in abis, f'arm64-v8a missing: {abis}'
+              print('ABIS=' + ','.join(abis))
+          PY
+
+          cat > release-output/build-identity.txt <<'EOF'
+          app=PDF Pro Tools
+          version=1.2.0
+          versionCode=3
+          androidPackage=com.codecsverige.pdf
+          build=debug-install-test
+          validation=signature+archive+badging+emulator-install-launch
+          EOF
+
+      - name: Free disk space before emulator
+        shell: bash
+        run: |
+          df -h
+          rm -rf android node_modules "$HOME/.gradle/caches" "$HOME/.npm/_cacache" || true
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost || true
+          df -h
+
+      - name: Enable KVM
+        shell: bash
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm || true
+
+      - name: Install and launch APK on Android emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 29
+          target: default
+          arch: x86_64
+          disk-size: 2048M
+          ram-size: 1536M
+          emulator-boot-timeout: 600
+          emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: |
+            set -euo pipefail
+            adb devices -l | tee release-output/adb-devices.txt
+            adb shell getprop sys.boot_completed | tee release-output/boot-completed.txt
+
+            adb install -r release-output/PDF-Pro-Tools-1.2.0.apk | tee release-output/install-result.txt
+            grep -q 'Success' release-output/install-result.txt
+
+            adb logcat -c
+            adb shell monkey -p com.codecsverige.pdf -c android.intent.category.LAUNCHER 1 | tee release-output/launch-result.txt
+            sleep 12
+
+            PID="$(adb shell pidof com.codecsverige.pdf | tr -d '\r')"
+            echo "PID=$PID" | tee release-output/process.txt
+            test -n "$PID"
+
+            adb shell dumpsys window | grep -E 'mCurrentFocus|mFocusedApp' | tee release-output/window-focus.txt || true
+            grep -q 'com.codecsverige.pdf' release-output/window-focus.txt
+
+            adb logcat -d --pid="$PID" -t 700 > release-output/startup-logcat.txt || true
+            if grep -Eqi 'FATAL EXCEPTION|AndroidRuntime.*FATAL' release-output/startup-logcat.txt; then
+              cat release-output/startup-logcat.txt
+              exit 1
+            fi
+
+            echo 'APK_INSTALL=PASS' | tee release-output/validated.txt
+            echo 'APP_LAUNCH=PASS' | tee -a release-output/validated.txt
+            echo 'PROCESS_ALIVE=PASS' | tee -a release-output/validated.txt
+
+      - name: Upload validated APK and evidence
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: pdf-pro-debug-apk
-          path: android/app/build/outputs/apk/debug/app-debug.apk
-          if-no-files-found: error
+          name: PDF-Pro-Tools-1.2.0-validated
+          path: release-output/
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -10,6 +10,7 @@ on:
       - 'package.json'
       - 'package-lock.json'
       - 'services/**'
+      - 'scripts/**'
       - 'assets/**'
       - '.github/workflows/android-build.yml'
   pull_request:
@@ -130,34 +131,7 @@ jobs:
           emulator-boot-timeout: 600
           emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: |
-            set -eu
-            adb devices -l | tee release-output/adb-devices.txt
-            adb shell getprop sys.boot_completed | tee release-output/boot-completed.txt
-
-            adb install -r release-output/PDF-Pro-Tools-1.2.0.apk | tee release-output/install-result.txt
-            grep -q 'Success' release-output/install-result.txt
-
-            adb logcat -c
-            adb shell monkey -p com.codecsverige.pdf -c android.intent.category.LAUNCHER 1 | tee release-output/launch-result.txt
-            sleep 12
-
-            PID="$(adb shell pidof com.codecsverige.pdf | tr -d '\r')"
-            echo "PID=$PID" | tee release-output/process.txt
-            test -n "$PID"
-
-            adb shell dumpsys window | grep -E 'mCurrentFocus|mFocusedApp' | tee release-output/window-focus.txt || true
-            grep -q 'com.codecsverige.pdf' release-output/window-focus.txt
-
-            adb logcat -d --pid="$PID" -t 700 > release-output/startup-logcat.txt || true
-            if grep -Eqi 'FATAL EXCEPTION|AndroidRuntime.*FATAL' release-output/startup-logcat.txt; then
-              cat release-output/startup-logcat.txt
-              exit 1
-            fi
-
-            echo 'APK_INSTALL=PASS' | tee release-output/validated.txt
-            echo 'APP_LAUNCH=PASS' | tee -a release-output/validated.txt
-            echo 'PROCESS_ALIVE=PASS' | tee -a release-output/validated.txt
+          script: bash scripts/smoke-emulator.sh
 
       - name: Upload validated APK and evidence
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [main, feat/pdf-pro-tools]
+  pull_request:
+    branches: [main]
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: TypeScript check
+        run: npx tsc --noEmit

--- a/App.tsx
+++ b/App.tsx
@@ -1,255 +1,403 @@
 import { StatusBar } from 'expo-status-bar';
-import * as ImagePicker from 'expo-image-picker';
 import * as DocumentPicker from 'expo-document-picker';
-import * as FileSystem from 'expo-file-system';
-import * as ImageManipulator from 'expo-image-manipulator';
+import * as ImagePicker from 'expo-image-picker';
 import * as Sharing from 'expo-sharing';
-import * as MediaLibrary from 'expo-media-library';
-import Constants from 'expo-constants';
-import { PDFDocument } from 'pdf-lib';
-import React, { useEffect, useState } from 'react';
-import { StyleSheet, Text, View, Pressable, FlatList, Image, Alert, Platform, Modal } from 'react-native';
-import { toByteArray } from 'base64-js';
-// Note: Avoid importing native-only libs in web; use native components instead
-import Paywall from './components/Paywall';
-import AdBanner from './components/AdBanner';
+import React, { useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  Pressable,
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import {
+  addPageNumbers,
+  extractPages,
+  getPdfPageCount,
+  mergePdfs,
+  PdfOutput,
+  reorderPages,
+  rotatePages,
+  watermarkPdf,
+} from './services/pdfEngine';
+import { ImageInput, imagesToPdf } from './services/imageToPdf';
+
+type ToolId = 'merge' | 'extract' | 'reorder' | 'rotate' | 'watermark' | 'numbers' | 'images';
+
+type SelectedPdf = {
+  uri: string;
+  name: string;
+  size?: number;
+  pages?: number;
+};
+
+type ToolDefinition = {
+  id: ToolId;
+  title: string;
+  description: string;
+  icon: string;
+};
+
+const TOOLS: ToolDefinition[] = [
+  { id: 'merge', title: 'Merge PDF', description: 'Combine multiple PDFs in the chosen order', icon: '⊕' },
+  { id: 'extract', title: 'Extract pages', description: 'Create a new PDF from selected pages', icon: '⇲' },
+  { id: 'reorder', title: 'Reorder pages', description: 'Build a new PDF with a custom page order', icon: '↕' },
+  { id: 'rotate', title: 'Rotate pages', description: 'Rotate all pages or only selected pages', icon: '↻' },
+  { id: 'watermark', title: 'Watermark', description: 'Burn a visible text watermark into every page', icon: 'W' },
+  { id: 'numbers', title: 'Page numbers', description: 'Add permanent page numbers to the PDF', icon: '#' },
+  { id: 'images', title: 'Images to PDF', description: 'Create an A4 PDF from multiple photos', icon: '▧' },
+];
+
+function formatBytes(bytes?: number) {
+  if (!bytes) return '';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : 'The PDF operation failed.';
+}
 
 export default function App() {
-  const [images, setImages] = useState<string[]>([]);
-  const [isBuilding, setIsBuilding] = useState<boolean>(false);
-  const [isPro, setIsPro] = useState<boolean>(false);
-  const [showPaywall, setShowPaywall] = useState<boolean>(false);
+  const [tool, setTool] = useState<ToolId | null>(null);
+  const [pdfs, setPdfs] = useState<SelectedPdf[]>([]);
+  const [images, setImages] = useState<ImageInput[]>([]);
+  const [pageExpression, setPageExpression] = useState('');
+  const [watermark, setWatermark] = useState('CONFIDENTIAL');
+  const [startAt, setStartAt] = useState('1');
+  const [rotation, setRotation] = useState<90 | 180 | 270>(90);
+  const [busy, setBusy] = useState(false);
+  const [result, setResult] = useState<PdfOutput | null>(null);
 
-  useEffect(() => {
-    // In web we skip native purchases/ads initialization.
-    // On native, AdBanner and Paywall handle their own native logic.
-    const extra: any = Constants.expoConfig?.extra ?? {};
-    // Potentially read extra in the future for feature flags
-  }, []);
+  const selectedTool = useMemo(() => TOOLS.find(item => item.id === tool) ?? null, [tool]);
+
+  function clearWorkspace(nextTool: ToolId | null = tool) {
+    setPdfs([]);
+    setImages([]);
+    setPageExpression('');
+    setWatermark('CONFIDENTIAL');
+    setStartAt('1');
+    setRotation(90);
+    setResult(null);
+    setTool(nextTool);
+  }
+
+  function openTool(id: ToolId) {
+    clearWorkspace(id);
+  }
+
+  async function pickPdf(multiple: boolean) {
+    const response = await DocumentPicker.getDocumentAsync({
+      type: 'application/pdf',
+      multiple,
+      copyToCacheDirectory: true,
+    });
+    if (response.canceled || !response.assets?.length) return;
+
+    const selected: SelectedPdf[] = response.assets.map(asset => ({
+      uri: asset.uri,
+      name: asset.name || 'document.pdf',
+      size: asset.size,
+    }));
+
+    if (!multiple) {
+      try {
+        selected[0].pages = await getPdfPageCount(selected[0].uri);
+      } catch (error) {
+        Alert.alert('Cannot open PDF', errorMessage(error));
+        return;
+      }
+      setPdfs([selected[0]]);
+    } else {
+      setPdfs(selected);
+    }
+    setResult(null);
+  }
 
   async function pickImages() {
-    const perm = await ImagePicker.requestMediaLibraryPermissionsAsync();
-    if (!perm.granted) {
-      Alert.alert('السماح مطلوب', 'يرجى منح إذن الصور.');
+    const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (!permission.granted) {
+      Alert.alert('Permission needed', 'Photo access is required to create a PDF from images.');
       return;
     }
-    const result = await ImagePicker.launchImageLibraryAsync({
+    const response = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ['images'],
       allowsMultipleSelection: true,
-      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      orderedSelection: true,
       quality: 1,
+      selectionLimit: 0,
     });
-    if (!result.canceled) {
-      const uris = result.assets?.map(a => a.uri) ?? [];
-      setImages(prev => [...prev, ...uris]);
-    }
+    if (response.canceled) return;
+    setImages(response.assets.map(asset => ({ uri: asset.uri, width: asset.width, height: asset.height })));
+    setResult(null);
   }
 
-  async function captureImage() {
-    const cam = await ImagePicker.requestCameraPermissionsAsync();
-    if (!cam.granted) {
-      Alert.alert('السماح مطلوب', 'يرجى منح إذن الكاميرا.');
-      return;
-    }
-    const result = await ImagePicker.launchCameraAsync({ quality: 1 });
-    if (!result.canceled) {
-      const uris = result.assets?.map(a => a.uri) ?? [];
-      setImages(prev => [...prev, ...uris]);
-    }
+  function removePdf(index: number) {
+    setPdfs(current => current.filter((_, itemIndex) => itemIndex !== index));
+    setResult(null);
   }
 
-  async function pickPdfFile() {
-    const res = await DocumentPicker.getDocumentAsync({ type: 'application/pdf', multiple: false, copyToCacheDirectory: true });
-    if (res.canceled || !res.assets?.length) return;
-    Alert.alert('ملف PDF محدد', 'يمكن دمج هذه الصفحات لاحقًا أو مشاركتها.');
-    // Placeholder: In future, merge/append existing PDF with images-generated PDF
-  }
-
-  async function buildPdf() {
-    if (images.length === 0) {
-      Alert.alert('لا صور', 'اختر صورًا أولاً.');
-      return;
-    }
-    setIsBuilding(true);
+  async function runTool() {
+    if (!tool) return;
+    setBusy(true);
+    setResult(null);
     try {
-      const pdfDoc = await PDFDocument.create();
-      for (const uri of images) {
-        // Compress and normalize to JPEG for consistent embedding
-        const manipulated = await ImageManipulator.manipulateAsync(
-          uri,
-          [{ resize: { width: 2000 } }],
-          { compress: 0.85, format: ImageManipulator.SaveFormat.JPEG, base64: true }
-        );
-        if (!manipulated.base64) continue;
-        const imgBytes = toByteArray(manipulated.base64);
-        const embedded = await pdfDoc.embedJpg(imgBytes);
-        const { width, height } = embedded.size();
-        const page = pdfDoc.addPage([width, height]);
-        page.drawImage(embedded, { x: 0, y: 0, width, height });
+      let output: PdfOutput;
+      switch (tool) {
+        case 'merge':
+          output = await mergePdfs(pdfs.map(item => item.uri));
+          break;
+        case 'extract':
+          if (!pdfs[0]) throw new Error('Choose a PDF first.');
+          output = await extractPages(pdfs[0].uri, pageExpression);
+          break;
+        case 'reorder':
+          if (!pdfs[0]) throw new Error('Choose a PDF first.');
+          output = await reorderPages(pdfs[0].uri, pageExpression);
+          break;
+        case 'rotate':
+          if (!pdfs[0]) throw new Error('Choose a PDF first.');
+          output = await rotatePages(pdfs[0].uri, pageExpression, rotation);
+          break;
+        case 'watermark':
+          if (!pdfs[0]) throw new Error('Choose a PDF first.');
+          output = await watermarkPdf(pdfs[0].uri, watermark);
+          break;
+        case 'numbers': {
+          if (!pdfs[0]) throw new Error('Choose a PDF first.');
+          const firstNumber = Number(startAt);
+          if (!Number.isInteger(firstNumber)) throw new Error('Start number must be a whole number.');
+          output = await addPageNumbers(pdfs[0].uri, firstNumber);
+          break;
+        }
+        case 'images':
+          output = await imagesToPdf(images, { pageMode: 'auto', jpegQuality: 0.9, margin: 28 });
+          break;
+        default:
+          throw new Error('Unknown tool.');
       }
-      const base64Pdf = await pdfDoc.saveAsBase64({ dataUri: false });
-      const fileUri = FileSystem.cacheDirectory + `scan_${Date.now()}.pdf`;
-      await FileSystem.writeAsStringAsync(fileUri, base64Pdf, { encoding: FileSystem.EncodingType.Base64 });
-
-      const mediaPerm = await MediaLibrary.requestPermissionsAsync();
-      if (mediaPerm.granted) {
-        await MediaLibrary.saveToLibraryAsync(fileUri);
-      }
-      if (await Sharing.isAvailableAsync()) {
-        await Sharing.shareAsync(fileUri, { mimeType: 'application/pdf', dialogTitle: 'مشاركة PDF' });
-      } else {
-        Alert.alert('جاهز', 'تم إنشاء PDF وحفظه.');
-      }
-    } catch (e: any) {
-      Alert.alert('خطأ', e?.message ?? 'فشل إنشاء PDF');
+      setResult(output);
+    } catch (error) {
+      Alert.alert('Operation failed', errorMessage(error));
     } finally {
-      setIsBuilding(false);
+      setBusy(false);
     }
   }
 
-  function clearImages() {
-    setImages([]);
-  }
-
-  function rotateImage(index: number) {
-    setImages(prev => {
-      const copy = [...prev];
-      const target = copy[index];
-      if (!target) return prev;
-      // Using query param as a cache-busting hint; real rotate happens before PDF via ImageManipulator
-      copy[index] = target + `#rot${Date.now()}`;
-      return copy;
+  async function shareResult() {
+    if (!result) return;
+    if (!(await Sharing.isAvailableAsync())) {
+      Alert.alert('Sharing unavailable', `The file was created at ${result.uri}`);
+      return;
+    }
+    await Sharing.shareAsync(result.uri, {
+      mimeType: 'application/pdf',
+      dialogTitle: 'Save or share PDF',
+      UTI: 'com.adobe.pdf',
     });
   }
 
-  function deleteImage(index: number) {
-    setImages(prev => prev.filter((_, i) => i !== index));
+  function actionLabel() {
+    switch (tool) {
+      case 'merge': return 'Merge PDFs';
+      case 'extract': return 'Extract pages';
+      case 'reorder': return 'Reorder pages';
+      case 'rotate': return 'Rotate pages';
+      case 'watermark': return 'Apply watermark';
+      case 'numbers': return 'Add page numbers';
+      case 'images': return 'Create PDF';
+      default: return 'Run';
+    }
   }
 
-  function moveImage(index: number, dir: -1 | 1) {
-    setImages(prev => {
-      const copy = [...prev];
-      const newIndex = index + dir;
-      if (newIndex < 0 || newIndex >= copy.length) return prev;
-      const [it] = copy.splice(index, 1);
-      copy.splice(newIndex, 0, it);
-      return copy;
-    });
-  }
+  const canRun = tool === 'images' ? images.length > 0 : tool === 'merge' ? pdfs.length >= 2 : pdfs.length === 1;
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>SwiftPDF Scanner</Text>
-      <View style={styles.buttonsRow}>
-        <Pressable style={styles.btn} onPress={pickImages}>
-          <Text style={styles.btnText}>اختر صور</Text>
-        </Pressable>
-        <Pressable style={styles.btn} onPress={captureImage}>
-          <Text style={styles.btnText}>التقط صورة</Text>
-        </Pressable>
-        <Pressable style={[styles.btn, isBuilding && styles.btnDisabled]} onPress={buildPdf} disabled={isBuilding}>
-          <Text style={styles.btnText}>{isBuilding ? 'جارٍ...' : 'إنشاء PDF'}</Text>
-        </Pressable>
-        <Pressable style={styles.btnOutline} onPress={pickPdfFile}>
-          <Text style={styles.btnText}>اختر ملف PDF</Text>
-        </Pressable>
-        {!isPro && (
-          <Pressable style={styles.btnOutline} onPress={() => setShowPaywall(true)}>
-            <Text style={styles.btnText}>ترقية</Text>
-          </Pressable>
-        )}
-        <Pressable style={styles.btnOutline} onPress={clearImages}>
-          <Text style={styles.btnText}>مسح</Text>
-        </Pressable>
-      </View>
-      <FlatList
-        data={images}
-        keyExtractor={(u, i) => u + i}
-        horizontal
-        contentContainerStyle={{ paddingVertical: 12 }}
-        showsHorizontalScrollIndicator={false}
-        renderItem={({ item, index }) => (
-          <View style={styles.thumbWrap}>
-            <Image source={{ uri: item }} style={styles.thumb} />
-            <View style={styles.thumbActions}>
-              <Pressable style={styles.smallBtn} onPress={() => moveImage(index, -1)}><Text style={styles.smallBtnText}>◀</Text></Pressable>
-              <Pressable style={styles.smallBtn} onPress={() => rotateImage(index)}><Text style={styles.smallBtnText}>⟳</Text></Pressable>
-              <Pressable style={styles.smallBtn} onPress={() => moveImage(index, 1)}><Text style={styles.smallBtnText}>▶</Text></Pressable>
-              <Pressable style={[styles.smallBtn, styles.delBtn]} onPress={() => deleteImage(index)}><Text style={styles.smallBtnText}>✕</Text></Pressable>
+    <SafeAreaView style={styles.safeArea}>
+      <StatusBar style="dark" />
+      <ScrollView contentContainerStyle={styles.container} keyboardShouldPersistTaps="handled">
+        <View style={styles.header}>
+          <View>
+            <Text style={styles.eyebrow}>OFFLINE PDF TOOLKIT</Text>
+            <Text style={styles.title}>PDF Pro Tools</Text>
+          </View>
+          {tool ? (
+            <Pressable style={styles.headerButton} onPress={() => clearWorkspace(null)}>
+              <Text style={styles.headerButtonText}>All tools</Text>
+            </Pressable>
+          ) : null}
+        </View>
+
+        {!tool ? (
+          <>
+            <Text style={styles.intro}>Only tools that actually modify the output PDF are shown here.</Text>
+            <View style={styles.toolGrid}>
+              {TOOLS.map(item => (
+                <Pressable key={item.id} style={styles.toolCard} onPress={() => openTool(item.id)}>
+                  <View style={styles.toolIcon}><Text style={styles.toolIconText}>{item.icon}</Text></View>
+                  <Text style={styles.toolTitle}>{item.title}</Text>
+                  <Text style={styles.toolDescription}>{item.description}</Text>
+                </Pressable>
+              ))}
             </View>
+          </>
+        ) : (
+          <View style={styles.workspace}>
+            <Text style={styles.workspaceTitle}>{selectedTool?.title}</Text>
+            <Text style={styles.workspaceDescription}>{selectedTool?.description}</Text>
+
+            {tool === 'images' ? (
+              <>
+                <Pressable style={styles.selectButton} onPress={pickImages}>
+                  <Text style={styles.selectButtonText}>{images.length ? 'Choose different images' : 'Choose images'}</Text>
+                </Pressable>
+                {images.length > 0 && <Text style={styles.selectionSummary}>{images.length} image(s) selected</Text>}
+              </>
+            ) : (
+              <>
+                <Pressable style={styles.selectButton} onPress={() => pickPdf(tool === 'merge')}>
+                  <Text style={styles.selectButtonText}>{tool === 'merge' ? 'Choose PDF files' : 'Choose PDF'}</Text>
+                </Pressable>
+                {pdfs.map((pdf, index) => (
+                  <View key={`${pdf.uri}-${index}`} style={styles.fileRow}>
+                    <View style={styles.fileInfo}>
+                      <Text style={styles.fileName} numberOfLines={1}>{pdf.name}</Text>
+                      <Text style={styles.fileMeta}>
+                        {[formatBytes(pdf.size), pdf.pages ? `${pdf.pages} pages` : ''].filter(Boolean).join(' • ')}
+                      </Text>
+                    </View>
+                    {tool === 'merge' && (
+                      <Pressable onPress={() => removePdf(index)} hitSlop={10}>
+                        <Text style={styles.removeText}>Remove</Text>
+                      </Pressable>
+                    )}
+                  </View>
+                ))}
+              </>
+            )}
+
+            {(tool === 'extract' || tool === 'reorder' || tool === 'rotate') && (
+              <View style={styles.fieldBlock}>
+                <Text style={styles.fieldLabel}>{tool === 'reorder' ? 'New page order' : 'Pages'}</Text>
+                <TextInput
+                  value={pageExpression}
+                  onChangeText={setPageExpression}
+                  placeholder={tool === 'rotate' ? 'Leave empty for all pages, or 1-3,5' : tool === 'reorder' ? 'Example: 3,1,2,4-8' : 'Example: 1-3,5,8'}
+                  placeholderTextColor="#94a3b8"
+                  style={styles.input}
+                  autoCapitalize="none"
+                />
+                <Text style={styles.helpText}>Page numbers are 1-based. Ranges are supported.</Text>
+              </View>
+            )}
+
+            {tool === 'rotate' && (
+              <View style={styles.segmentRow}>
+                {[90, 180, 270].map(value => (
+                  <Pressable
+                    key={value}
+                    style={[styles.segment, rotation === value && styles.segmentActive]}
+                    onPress={() => setRotation(value as 90 | 180 | 270)}
+                  >
+                    <Text style={[styles.segmentText, rotation === value && styles.segmentTextActive]}>{value}°</Text>
+                  </Pressable>
+                ))}
+              </View>
+            )}
+
+            {tool === 'watermark' && (
+              <View style={styles.fieldBlock}>
+                <Text style={styles.fieldLabel}>Watermark text</Text>
+                <TextInput value={watermark} onChangeText={setWatermark} style={styles.input} maxLength={80} />
+                <Text style={styles.helpText}>This first engine uses the built-in PDF Latin font. Unicode font embedding comes separately.</Text>
+              </View>
+            )}
+
+            {tool === 'numbers' && (
+              <View style={styles.fieldBlock}>
+                <Text style={styles.fieldLabel}>Start numbering at</Text>
+                <TextInput value={startAt} onChangeText={setStartAt} keyboardType="number-pad" style={styles.input} />
+              </View>
+            )}
+
+            <Pressable
+              style={[styles.runButton, (!canRun || busy) && styles.disabled]}
+              onPress={runTool}
+              disabled={!canRun || busy}
+            >
+              {busy ? <ActivityIndicator color="#ffffff" /> : <Text style={styles.runButtonText}>{actionLabel()}</Text>}
+            </Pressable>
+
+            {result && (
+              <View style={styles.resultCard}>
+                <View style={styles.resultBadge}><Text style={styles.resultBadgeText}>✓</Text></View>
+                <View style={styles.resultContent}>
+                  <Text style={styles.resultTitle}>PDF created successfully</Text>
+                  <Text style={styles.resultName}>{result.fileName}</Text>
+                  <Text style={styles.resultMeta}>{result.pageCount} pages • {formatBytes(result.bytes)}</Text>
+                </View>
+                <Pressable style={styles.shareButton} onPress={shareResult}>
+                  <Text style={styles.shareButtonText}>Save / Share</Text>
+                </Pressable>
+              </View>
+            )}
           </View>
         )}
-      />
-      <StatusBar style="auto" />
-      {!isPro && <AdBanner />}
-      <Paywall visible={showPaywall} onClose={() => setShowPaywall(false)} onPurchased={() => { setIsPro(true); setShowPaywall(false); }} />
-    </View>
+      </ScrollView>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-    paddingTop: 64,
-    paddingHorizontal: 16,
-  },
-  title: {
-    fontSize: 22,
-    fontWeight: '600',
-    marginBottom: 12,
-  },
-  buttonsRow: {
-    flexDirection: 'row',
-    gap: 12,
-  },
-  btn: {
-    backgroundColor: '#2563eb',
-    paddingHorizontal: 14,
-    paddingVertical: 10,
-    borderRadius: 8,
-  },
-  btnOutline: {
-    borderWidth: 1,
-    borderColor: '#2563eb',
-    paddingHorizontal: 14,
-    paddingVertical: 10,
-    borderRadius: 8,
-  },
-  btnDisabled: {
-    opacity: 0.6,
-  },
-  btnText: {
-    color: '#fff',
-    fontWeight: '600',
-  },
-  thumbWrap: {
-    marginRight: 8,
-  },
-  thumb: {
-    width: 100,
-    height: 140,
-    borderRadius: 8,
-    marginRight: 8,
-    backgroundColor: '#eee',
-  },
-  thumbActions: {
-    flexDirection: 'row',
-    marginTop: 4,
-    gap: 6,
-    justifyContent: 'center',
-  },
-  smallBtn: {
-    backgroundColor: '#111827',
-    paddingHorizontal: 8,
-    paddingVertical: 6,
-    borderRadius: 6,
-  },
-  delBtn: {
-    backgroundColor: '#dc2626',
-  },
-  smallBtnText: {
-    color: '#fff',
-    fontWeight: '700',
-    fontSize: 12,
-  },
+  safeArea: { flex: 1, backgroundColor: '#f8fafc' },
+  container: { paddingHorizontal: 18, paddingTop: 24, paddingBottom: 48 },
+  header: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginBottom: 20 },
+  eyebrow: { color: '#2563eb', fontSize: 11, fontWeight: '800', letterSpacing: 1.4 },
+  title: { color: '#0f172a', fontSize: 30, lineHeight: 36, fontWeight: '800', marginTop: 2 },
+  headerButton: { paddingHorizontal: 13, paddingVertical: 9, borderRadius: 10, backgroundColor: '#e2e8f0' },
+  headerButtonText: { color: '#334155', fontWeight: '700' },
+  intro: { color: '#64748b', fontSize: 15, lineHeight: 22, marginBottom: 18 },
+  toolGrid: { gap: 12 },
+  toolCard: { backgroundColor: '#ffffff', borderWidth: 1, borderColor: '#e2e8f0', borderRadius: 18, padding: 17 },
+  toolIcon: { width: 38, height: 38, borderRadius: 11, backgroundColor: '#eff6ff', alignItems: 'center', justifyContent: 'center', marginBottom: 12 },
+  toolIconText: { color: '#2563eb', fontSize: 20, fontWeight: '800' },
+  toolTitle: { color: '#0f172a', fontSize: 17, fontWeight: '800' },
+  toolDescription: { color: '#64748b', fontSize: 14, lineHeight: 20, marginTop: 4 },
+  workspace: { backgroundColor: '#ffffff', borderWidth: 1, borderColor: '#e2e8f0', borderRadius: 20, padding: 18 },
+  workspaceTitle: { color: '#0f172a', fontSize: 24, fontWeight: '800' },
+  workspaceDescription: { color: '#64748b', fontSize: 14, lineHeight: 20, marginTop: 5, marginBottom: 18 },
+  selectButton: { borderWidth: 1.5, borderStyle: 'dashed', borderColor: '#93c5fd', backgroundColor: '#eff6ff', borderRadius: 14, paddingVertical: 16, alignItems: 'center' },
+  selectButtonText: { color: '#1d4ed8', fontSize: 15, fontWeight: '800' },
+  selectionSummary: { marginTop: 10, color: '#475569', fontWeight: '600' },
+  fileRow: { flexDirection: 'row', alignItems: 'center', marginTop: 10, padding: 12, backgroundColor: '#f8fafc', borderRadius: 12, borderWidth: 1, borderColor: '#e2e8f0' },
+  fileInfo: { flex: 1, minWidth: 0 },
+  fileName: { color: '#0f172a', fontWeight: '700' },
+  fileMeta: { color: '#64748b', fontSize: 12, marginTop: 3 },
+  removeText: { color: '#dc2626', fontSize: 13, fontWeight: '700', marginLeft: 12 },
+  fieldBlock: { marginTop: 18 },
+  fieldLabel: { color: '#334155', fontSize: 13, fontWeight: '800', marginBottom: 7 },
+  input: { borderWidth: 1, borderColor: '#cbd5e1', backgroundColor: '#ffffff', color: '#0f172a', borderRadius: 12, paddingHorizontal: 13, paddingVertical: 12, fontSize: 15 },
+  helpText: { color: '#64748b', fontSize: 12, lineHeight: 18, marginTop: 6 },
+  segmentRow: { flexDirection: 'row', gap: 8, marginTop: 12 },
+  segment: { flex: 1, paddingVertical: 10, alignItems: 'center', borderRadius: 10, backgroundColor: '#f1f5f9', borderWidth: 1, borderColor: '#e2e8f0' },
+  segmentActive: { backgroundColor: '#2563eb', borderColor: '#2563eb' },
+  segmentText: { color: '#475569', fontWeight: '800' },
+  segmentTextActive: { color: '#ffffff' },
+  runButton: { backgroundColor: '#2563eb', borderRadius: 14, paddingVertical: 15, alignItems: 'center', justifyContent: 'center', minHeight: 52, marginTop: 22 },
+  runButtonText: { color: '#ffffff', fontSize: 16, fontWeight: '800' },
+  disabled: { opacity: 0.45 },
+  resultCard: { marginTop: 18, padding: 14, borderRadius: 15, backgroundColor: '#f0fdf4', borderWidth: 1, borderColor: '#bbf7d0' },
+  resultBadge: { width: 30, height: 30, borderRadius: 15, backgroundColor: '#16a34a', alignItems: 'center', justifyContent: 'center', marginBottom: 10 },
+  resultBadgeText: { color: '#ffffff', fontWeight: '900' },
+  resultContent: { marginBottom: 12 },
+  resultTitle: { color: '#166534', fontWeight: '800', fontSize: 15 },
+  resultName: { color: '#14532d', marginTop: 4, fontWeight: '600' },
+  resultMeta: { color: '#15803d', fontSize: 12, marginTop: 3 },
+  shareButton: { backgroundColor: '#166534', borderRadius: 11, paddingVertical: 11, alignItems: 'center' },
+  shareButtonText: { color: '#ffffff', fontWeight: '800' },
 });

--- a/App.tsx
+++ b/App.tsx
@@ -16,18 +16,29 @@ import {
 } from 'react-native';
 import {
   addPageNumbers,
+  deletePages,
   extractPages,
   getPdfPageCount,
   mergePdfs,
-  PdfOutput,
   reorderPages,
   rotatePages,
   watermarkPdf,
 } from './services/pdfEngine';
-import { ImageInput, imagesToPdf } from './services/imageToPdf';
+import type { PdfOutput } from './services/pdfEngine';
+import { imagesToPdf } from './services/imageToPdf';
+import type { ImageInput } from './services/imageToPdf';
 import { savePdfToChosenFolder } from './services/savePdf';
 
-type ToolId = 'merge' | 'extract' | 'reorder' | 'rotate' | 'watermark' | 'numbers' | 'images';
+type ToolId =
+  | 'merge'
+  | 'extract'
+  | 'delete'
+  | 'reorder'
+  | 'rotate'
+  | 'watermark'
+  | 'numbers'
+  | 'images'
+  | 'scan';
 
 type SelectedPdf = {
   uri: string;
@@ -44,13 +55,15 @@ type ToolDefinition = {
 };
 
 const TOOLS: ToolDefinition[] = [
-  { id: 'merge', title: 'Merge PDF', description: 'Combine multiple PDFs in the chosen order', icon: '⊕' },
-  { id: 'extract', title: 'Extract pages', description: 'Create a new PDF from selected pages', icon: '⇲' },
-  { id: 'reorder', title: 'Reorder pages', description: 'Build a new PDF with a custom page order', icon: '↕' },
-  { id: 'rotate', title: 'Rotate pages', description: 'Rotate all pages or only selected pages', icon: '↻' },
-  { id: 'watermark', title: 'Watermark', description: 'Burn a visible text watermark into every page', icon: 'W' },
-  { id: 'numbers', title: 'Page numbers', description: 'Add permanent page numbers to the PDF', icon: '#' },
-  { id: 'images', title: 'Images to PDF', description: 'Create an A4 PDF from multiple photos', icon: '▧' },
+  { id: 'merge', title: 'Merge PDF', description: 'Combine several PDFs in the exact order you choose.', icon: '⊕' },
+  { id: 'extract', title: 'Extract pages', description: 'Create a new PDF from selected pages.', icon: '⇲' },
+  { id: 'delete', title: 'Delete pages', description: 'Remove unwanted pages and keep the rest.', icon: '−' },
+  { id: 'reorder', title: 'Reorder pages', description: 'Build a new PDF with a custom page order.', icon: '↕' },
+  { id: 'rotate', title: 'Rotate pages', description: 'Rotate all pages or only the pages you select.', icon: '↻' },
+  { id: 'watermark', title: 'Watermark', description: 'Burn a visible text watermark into every page.', icon: 'W' },
+  { id: 'numbers', title: 'Page numbers', description: 'Add permanent page numbers to the PDF.', icon: '#' },
+  { id: 'images', title: 'Images to PDF', description: 'Turn multiple photos into one A4 PDF.', icon: '▧' },
+  { id: 'scan', title: 'Camera to PDF', description: 'Capture document pages with the camera and create a PDF.', icon: '⌁' },
 ];
 
 function formatBytes(bytes?: number) {
@@ -94,49 +107,82 @@ export default function App() {
   }
 
   async function pickPdf(multiple: boolean) {
-    const response = await DocumentPicker.getDocumentAsync({
-      type: 'application/pdf',
-      multiple,
-      copyToCacheDirectory: true,
-    });
-    if (response.canceled || !response.assets?.length) return;
+    try {
+      const response = await DocumentPicker.getDocumentAsync({
+        type: 'application/pdf',
+        multiple,
+        copyToCacheDirectory: true,
+      });
+      if (response.canceled || !response.assets?.length) return;
 
-    const selected: SelectedPdf[] = response.assets.map(asset => ({
-      uri: asset.uri,
-      name: asset.name || 'document.pdf',
-      size: asset.size,
-    }));
+      const selected: SelectedPdf[] = response.assets.map(asset => ({
+        uri: asset.uri,
+        name: asset.name || 'document.pdf',
+        size: asset.size,
+      }));
 
-    if (!multiple) {
-      try {
+      if (!multiple) {
         selected[0].pages = await getPdfPageCount(selected[0].uri);
-      } catch (error) {
-        Alert.alert('Cannot open PDF', errorMessage(error));
-        return;
+        setPdfs([selected[0]]);
+      } else {
+        setPdfs(selected);
       }
-      setPdfs([selected[0]]);
-    } else {
-      setPdfs(selected);
+      setResult(null);
+    } catch (error) {
+      Alert.alert('Cannot open PDF', errorMessage(error));
     }
-    setResult(null);
   }
 
   async function pickImages() {
-    const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
-    if (!permission.granted) {
-      Alert.alert('Permission needed', 'Photo access is required to create a PDF from images.');
-      return;
+    try {
+      const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
+      if (!permission.granted) {
+        Alert.alert('Permission needed', 'Photo access is required to create a PDF from images.');
+        return;
+      }
+
+      const response = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ['images'],
+        allowsMultipleSelection: true,
+        orderedSelection: true,
+        quality: 1,
+        selectionLimit: 0,
+      });
+      if (response.canceled) return;
+
+      setImages(
+        response.assets.map(asset => ({
+          uri: asset.uri,
+          width: asset.width,
+          height: asset.height,
+        })),
+      );
+      setResult(null);
+    } catch (error) {
+      Alert.alert('Could not select images', errorMessage(error));
     }
-    const response = await ImagePicker.launchImageLibraryAsync({
-      mediaTypes: ['images'],
-      allowsMultipleSelection: true,
-      orderedSelection: true,
-      quality: 1,
-      selectionLimit: 0,
-    });
-    if (response.canceled) return;
-    setImages(response.assets.map(asset => ({ uri: asset.uri, width: asset.width, height: asset.height })));
-    setResult(null);
+  }
+
+  async function capturePage() {
+    try {
+      const permission = await ImagePicker.requestCameraPermissionsAsync();
+      if (!permission.granted) {
+        Alert.alert('Permission needed', 'Camera access is required to capture a document page.');
+        return;
+      }
+
+      const response = await ImagePicker.launchCameraAsync({ quality: 1 });
+      if (response.canceled || !response.assets?.length) return;
+
+      const asset = response.assets[0];
+      setImages(current => [
+        ...current,
+        { uri: asset.uri, width: asset.width, height: asset.height },
+      ]);
+      setResult(null);
+    } catch (error) {
+      Alert.alert('Camera failed', errorMessage(error));
+    }
   }
 
   function removePdf(index: number) {
@@ -144,10 +190,22 @@ export default function App() {
     setResult(null);
   }
 
+  function movePdf(index: number, direction: -1 | 1) {
+    setPdfs(current => {
+      const target = index + direction;
+      if (target < 0 || target >= current.length) return current;
+      const next = [...current];
+      [next[index], next[target]] = [next[target], next[index]];
+      return next;
+    });
+    setResult(null);
+  }
+
   async function runTool() {
     if (!tool) return;
     setBusy(true);
     setResult(null);
+
     try {
       let output: PdfOutput;
       switch (tool) {
@@ -157,6 +215,10 @@ export default function App() {
         case 'extract':
           if (!pdfs[0]) throw new Error('Choose a PDF first.');
           output = await extractPages(pdfs[0].uri, pageExpression);
+          break;
+        case 'delete':
+          if (!pdfs[0]) throw new Error('Choose a PDF first.');
+          output = await deletePages(pdfs[0].uri, pageExpression);
           break;
         case 'reorder':
           if (!pdfs[0]) throw new Error('Choose a PDF first.');
@@ -173,12 +235,20 @@ export default function App() {
         case 'numbers': {
           if (!pdfs[0]) throw new Error('Choose a PDF first.');
           const firstNumber = Number(startAt);
-          if (!Number.isInteger(firstNumber)) throw new Error('Start number must be a whole number.');
+          if (!Number.isInteger(firstNumber) || firstNumber < 0) {
+            throw new Error('Start number must be a whole number of 0 or greater.');
+          }
           output = await addPageNumbers(pdfs[0].uri, firstNumber);
           break;
         }
         case 'images':
-          output = await imagesToPdf(images, { pageMode: 'auto', jpegQuality: 0.9, margin: 28 });
+        case 'scan':
+          output = await imagesToPdf(images, {
+            pageMode: 'auto',
+            jpegQuality: 0.88,
+            maxImageWidth: 2200,
+            margin: 28,
+          });
           break;
         default:
           throw new Error('Unknown tool.');
@@ -195,8 +265,8 @@ export default function App() {
     if (!result) return;
     setSaving(true);
     try {
-      await savePdfToChosenFolder(result.uri, result.fileName);
-      Alert.alert('Saved', 'The PDF was copied to the folder you selected.');
+      const destination = await savePdfToChosenFolder(result.uri, result.fileName);
+      if (destination) Alert.alert('Saved', 'The PDF was copied to the folder you selected.');
     } catch (error) {
       Alert.alert('Could not save PDF', errorMessage(error));
     } finally {
@@ -206,38 +276,51 @@ export default function App() {
 
   async function shareResult() {
     if (!result) return;
-    if (!(await Sharing.isAvailableAsync())) {
-      Alert.alert('Sharing unavailable', `The file was created at ${result.uri}`);
-      return;
+    try {
+      if (!(await Sharing.isAvailableAsync())) {
+        Alert.alert('Sharing unavailable', 'Use “Save to folder” to keep the generated PDF.');
+        return;
+      }
+      await Sharing.shareAsync(result.uri, {
+        mimeType: 'application/pdf',
+        dialogTitle: 'Share PDF',
+        UTI: 'com.adobe.pdf',
+      });
+    } catch (error) {
+      Alert.alert('Could not share PDF', errorMessage(error));
     }
-    await Sharing.shareAsync(result.uri, {
-      mimeType: 'application/pdf',
-      dialogTitle: 'Share PDF',
-      UTI: 'com.adobe.pdf',
-    });
   }
 
   function actionLabel() {
     switch (tool) {
       case 'merge': return 'Merge PDFs';
       case 'extract': return 'Extract pages';
+      case 'delete': return 'Delete pages';
       case 'reorder': return 'Reorder pages';
       case 'rotate': return 'Rotate pages';
       case 'watermark': return 'Apply watermark';
       case 'numbers': return 'Add page numbers';
       case 'images': return 'Create PDF';
+      case 'scan': return 'Create scanned PDF';
       default: return 'Run';
     }
   }
 
-  const canRun = tool === 'images' ? images.length > 0 : tool === 'merge' ? pdfs.length >= 2 : pdfs.length === 1;
+  const canRun =
+    tool === 'images' || tool === 'scan'
+      ? images.length > 0
+      : tool === 'merge'
+        ? pdfs.length >= 2
+        : pdfs.length === 1;
+
+  const usesPageExpression = tool === 'extract' || tool === 'delete' || tool === 'reorder' || tool === 'rotate';
 
   return (
     <SafeAreaView style={styles.safeArea}>
       <StatusBar style="dark" />
       <ScrollView contentContainerStyle={styles.container} keyboardShouldPersistTaps="handled">
         <View style={styles.header}>
-          <View>
+          <View style={styles.headerTextWrap}>
             <Text style={styles.eyebrow}>OFFLINE PDF TOOLKIT</Text>
             <Text style={styles.title}>PDF Pro Tools</Text>
           </View>
@@ -250,68 +333,132 @@ export default function App() {
 
         {!tool ? (
           <>
-            <Text style={styles.intro}>Only tools that actually modify the output PDF are shown here.</Text>
+            <View style={styles.heroCard}>
+              <Text style={styles.heroTitle}>Real PDF editing, on your phone</Text>
+              <Text style={styles.heroText}>
+                Files are processed locally. Choose a tool, create the result, then save or share it.
+              </Text>
+            </View>
+
             <View style={styles.toolGrid}>
               {TOOLS.map(item => (
                 <Pressable key={item.id} style={styles.toolCard} onPress={() => openTool(item.id)}>
-                  <View style={styles.toolIcon}><Text style={styles.toolIconText}>{item.icon}</Text></View>
+                  <View style={styles.toolIcon}>
+                    <Text style={styles.toolIconText}>{item.icon}</Text>
+                  </View>
                   <Text style={styles.toolTitle}>{item.title}</Text>
                   <Text style={styles.toolDescription}>{item.description}</Text>
                 </Pressable>
               ))}
             </View>
+
+            <Text style={styles.footerNote}>
+              Password removal, OCR and full text editing are not shown because this build does not pretend to provide features it cannot perform reliably.
+            </Text>
           </>
         ) : (
           <View style={styles.workspace}>
-            <Text style={styles.workspaceTitle}>{selectedTool?.title}</Text>
-            <Text style={styles.workspaceDescription}>{selectedTool?.description}</Text>
+            <View style={styles.workspaceHeading}>
+              <View style={styles.workspaceIcon}>
+                <Text style={styles.workspaceIconText}>{selectedTool?.icon}</Text>
+              </View>
+              <View style={styles.workspaceHeadingText}>
+                <Text style={styles.workspaceTitle}>{selectedTool?.title}</Text>
+                <Text style={styles.workspaceDescription}>{selectedTool?.description}</Text>
+              </View>
+            </View>
 
             {tool === 'images' ? (
               <>
                 <Pressable style={styles.selectButton} onPress={pickImages}>
                   <Text style={styles.selectButtonText}>{images.length ? 'Choose different images' : 'Choose images'}</Text>
                 </Pressable>
-                {images.length > 0 && <Text style={styles.selectionSummary}>{images.length} image(s) selected</Text>}
+                {images.length > 0 ? (
+                  <View style={styles.selectionCard}>
+                    <Text style={styles.selectionTitle}>{images.length} image(s) selected</Text>
+                    <Text style={styles.selectionMeta}>Selection order becomes PDF page order.</Text>
+                  </View>
+                ) : null}
+              </>
+            ) : tool === 'scan' ? (
+              <>
+                <Pressable style={styles.selectButton} onPress={capturePage}>
+                  <Text style={styles.selectButtonText}>{images.length ? 'Capture another page' : 'Capture first page'}</Text>
+                </Pressable>
+                {images.length > 0 ? (
+                  <View style={styles.selectionCard}>
+                    <Text style={styles.selectionTitle}>{images.length} captured page(s)</Text>
+                    <View style={styles.inlineActions}>
+                      <Pressable style={styles.minorButton} onPress={() => setImages(current => current.slice(0, -1))}>
+                        <Text style={styles.minorButtonText}>Remove last</Text>
+                      </Pressable>
+                      <Pressable style={styles.minorButton} onPress={() => setImages([])}>
+                        <Text style={styles.minorButtonText}>Clear</Text>
+                      </Pressable>
+                    </View>
+                  </View>
+                ) : null}
               </>
             ) : (
               <>
                 <Pressable style={styles.selectButton} onPress={() => pickPdf(tool === 'merge')}>
                   <Text style={styles.selectButtonText}>{tool === 'merge' ? 'Choose PDF files' : 'Choose PDF'}</Text>
                 </Pressable>
+
                 {pdfs.map((pdf, index) => (
                   <View key={`${pdf.uri}-${index}`} style={styles.fileRow}>
+                    <View style={styles.fileOrderBadge}>
+                      <Text style={styles.fileOrderText}>{index + 1}</Text>
+                    </View>
                     <View style={styles.fileInfo}>
                       <Text style={styles.fileName} numberOfLines={1}>{pdf.name}</Text>
                       <Text style={styles.fileMeta}>
-                        {[formatBytes(pdf.size), pdf.pages ? `${pdf.pages} pages` : ''].filter(Boolean).join(' • ')}
+                        {[formatBytes(pdf.size), pdf.pages ? `${pdf.pages} pages` : ''].filter(Boolean).join(' • ') || 'PDF file'}
                       </Text>
                     </View>
-                    {tool === 'merge' && (
-                      <Pressable onPress={() => removePdf(index)} hitSlop={10}>
-                        <Text style={styles.removeText}>Remove</Text>
-                      </Pressable>
-                    )}
+                    {tool === 'merge' ? (
+                      <View style={styles.fileActions}>
+                        <Pressable disabled={index === 0} onPress={() => movePdf(index, -1)} hitSlop={8}>
+                          <Text style={[styles.fileActionText, index === 0 && styles.muted]}>↑</Text>
+                        </Pressable>
+                        <Pressable disabled={index === pdfs.length - 1} onPress={() => movePdf(index, 1)} hitSlop={8}>
+                          <Text style={[styles.fileActionText, index === pdfs.length - 1 && styles.muted]}>↓</Text>
+                        </Pressable>
+                        <Pressable onPress={() => removePdf(index)} hitSlop={8}>
+                          <Text style={styles.removeText}>×</Text>
+                        </Pressable>
+                      </View>
+                    ) : null}
                   </View>
                 ))}
               </>
             )}
 
-            {(tool === 'extract' || tool === 'reorder' || tool === 'rotate') && (
+            {usesPageExpression ? (
               <View style={styles.fieldBlock}>
-                <Text style={styles.fieldLabel}>{tool === 'reorder' ? 'New page order' : 'Pages'}</Text>
+                <Text style={styles.fieldLabel}>
+                  {tool === 'reorder' ? 'New page order' : tool === 'delete' ? 'Pages to delete' : 'Pages'}
+                </Text>
                 <TextInput
                   value={pageExpression}
                   onChangeText={setPageExpression}
-                  placeholder={tool === 'rotate' ? 'Leave empty for all pages, or 1-3,5' : tool === 'reorder' ? 'Example: 3,1,2,4-8' : 'Example: 1-3,5,8'}
+                  placeholder={
+                    tool === 'rotate'
+                      ? 'Leave empty for all pages, or 1-3,5'
+                      : tool === 'reorder'
+                        ? 'Example: 3,1,2,4-8'
+                        : 'Example: 1-3,5,8'
+                  }
                   placeholderTextColor="#94a3b8"
                   style={styles.input}
                   autoCapitalize="none"
+                  autoCorrect={false}
                 />
-                <Text style={styles.helpText}>Page numbers are 1-based. Ranges are supported.</Text>
+                <Text style={styles.helpText}>Page numbers start at 1. Commas and ranges are supported.</Text>
               </View>
-            )}
+            ) : null}
 
-            {tool === 'rotate' && (
+            {tool === 'rotate' ? (
               <View style={styles.segmentRow}>
                 {[90, 180, 270].map(value => (
                   <Pressable
@@ -323,22 +470,22 @@ export default function App() {
                   </Pressable>
                 ))}
               </View>
-            )}
+            ) : null}
 
-            {tool === 'watermark' && (
+            {tool === 'watermark' ? (
               <View style={styles.fieldBlock}>
                 <Text style={styles.fieldLabel}>Watermark text</Text>
                 <TextInput value={watermark} onChangeText={setWatermark} style={styles.input} maxLength={80} />
-                <Text style={styles.helpText}>This first engine uses the built-in PDF Latin font. Unicode font embedding comes separately.</Text>
+                <Text style={styles.helpText}>Latin text is supported in this offline watermark engine.</Text>
               </View>
-            )}
+            ) : null}
 
-            {tool === 'numbers' && (
+            {tool === 'numbers' ? (
               <View style={styles.fieldBlock}>
                 <Text style={styles.fieldLabel}>Start numbering at</Text>
                 <TextInput value={startAt} onChangeText={setStartAt} keyboardType="number-pad" style={styles.input} />
               </View>
-            )}
+            ) : null}
 
             <Pressable
               style={[styles.runButton, (!canRun || busy) && styles.disabled]}
@@ -348,9 +495,11 @@ export default function App() {
               {busy ? <ActivityIndicator color="#ffffff" /> : <Text style={styles.runButtonText}>{actionLabel()}</Text>}
             </Pressable>
 
-            {result && (
+            {result ? (
               <View style={styles.resultCard}>
-                <View style={styles.resultBadge}><Text style={styles.resultBadgeText}>✓</Text></View>
+                <View style={styles.resultBadge}>
+                  <Text style={styles.resultBadgeText}>✓</Text>
+                </View>
                 <View style={styles.resultContent}>
                   <Text style={styles.resultTitle}>PDF created successfully</Text>
                   <Text style={styles.resultName}>{result.fileName}</Text>
@@ -365,7 +514,7 @@ export default function App() {
                   </Pressable>
                 </View>
               </View>
-            )}
+            ) : null}
           </View>
         )}
       </ScrollView>
@@ -376,51 +525,69 @@ export default function App() {
 const styles = StyleSheet.create({
   safeArea: { flex: 1, backgroundColor: '#f8fafc' },
   container: { paddingHorizontal: 18, paddingTop: 24, paddingBottom: 48 },
-  header: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginBottom: 20 },
+  header: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginBottom: 20, gap: 12 },
+  headerTextWrap: { flex: 1 },
   eyebrow: { color: '#2563eb', fontSize: 11, fontWeight: '800', letterSpacing: 1.4 },
   title: { color: '#0f172a', fontSize: 30, lineHeight: 36, fontWeight: '800', marginTop: 2 },
   headerButton: { paddingHorizontal: 13, paddingVertical: 9, borderRadius: 10, backgroundColor: '#e2e8f0' },
   headerButtonText: { color: '#334155', fontWeight: '700' },
-  intro: { color: '#64748b', fontSize: 15, lineHeight: 22, marginBottom: 18 },
-  toolGrid: { gap: 12 },
-  toolCard: { backgroundColor: '#ffffff', borderWidth: 1, borderColor: '#e2e8f0', borderRadius: 18, padding: 17 },
+  heroCard: { backgroundColor: '#0f172a', borderRadius: 20, padding: 20, marginBottom: 18 },
+  heroTitle: { color: '#ffffff', fontSize: 20, fontWeight: '800', marginBottom: 8 },
+  heroText: { color: '#cbd5e1', fontSize: 14, lineHeight: 21 },
+  toolGrid: { flexDirection: 'row', flexWrap: 'wrap', gap: 12 },
+  toolCard: { width: '48%', minHeight: 150, backgroundColor: '#ffffff', borderRadius: 16, padding: 15, borderWidth: 1, borderColor: '#e2e8f0' },
   toolIcon: { width: 38, height: 38, borderRadius: 11, backgroundColor: '#eff6ff', alignItems: 'center', justifyContent: 'center', marginBottom: 12 },
   toolIconText: { color: '#2563eb', fontSize: 20, fontWeight: '800' },
-  toolTitle: { color: '#0f172a', fontSize: 17, fontWeight: '800' },
-  toolDescription: { color: '#64748b', fontSize: 14, lineHeight: 20, marginTop: 4 },
-  workspace: { backgroundColor: '#ffffff', borderWidth: 1, borderColor: '#e2e8f0', borderRadius: 20, padding: 18 },
-  workspaceTitle: { color: '#0f172a', fontSize: 24, fontWeight: '800' },
-  workspaceDescription: { color: '#64748b', fontSize: 14, lineHeight: 20, marginTop: 5, marginBottom: 18 },
-  selectButton: { borderWidth: 1.5, borderStyle: 'dashed', borderColor: '#93c5fd', backgroundColor: '#eff6ff', borderRadius: 14, paddingVertical: 16, alignItems: 'center' },
-  selectButtonText: { color: '#1d4ed8', fontSize: 15, fontWeight: '800' },
-  selectionSummary: { marginTop: 10, color: '#475569', fontWeight: '600' },
-  fileRow: { flexDirection: 'row', alignItems: 'center', marginTop: 10, padding: 12, backgroundColor: '#f8fafc', borderRadius: 12, borderWidth: 1, borderColor: '#e2e8f0' },
+  toolTitle: { color: '#0f172a', fontSize: 15, fontWeight: '800', marginBottom: 5 },
+  toolDescription: { color: '#64748b', fontSize: 12, lineHeight: 18 },
+  footerNote: { color: '#64748b', fontSize: 12, lineHeight: 18, marginTop: 18, textAlign: 'center' },
+  workspace: { backgroundColor: '#ffffff', borderRadius: 20, padding: 18, borderWidth: 1, borderColor: '#e2e8f0' },
+  workspaceHeading: { flexDirection: 'row', alignItems: 'center', gap: 12, marginBottom: 18 },
+  workspaceIcon: { width: 46, height: 46, borderRadius: 14, backgroundColor: '#eff6ff', alignItems: 'center', justifyContent: 'center' },
+  workspaceIconText: { color: '#2563eb', fontSize: 23, fontWeight: '800' },
+  workspaceHeadingText: { flex: 1 },
+  workspaceTitle: { color: '#0f172a', fontSize: 22, fontWeight: '800', marginBottom: 3 },
+  workspaceDescription: { color: '#64748b', fontSize: 13, lineHeight: 19 },
+  selectButton: { backgroundColor: '#2563eb', borderRadius: 12, paddingVertical: 14, paddingHorizontal: 16, alignItems: 'center', marginBottom: 12 },
+  selectButtonText: { color: '#ffffff', fontSize: 15, fontWeight: '800' },
+  selectionCard: { backgroundColor: '#f8fafc', borderRadius: 12, padding: 14, borderWidth: 1, borderColor: '#e2e8f0', marginBottom: 12 },
+  selectionTitle: { color: '#0f172a', fontWeight: '800', marginBottom: 4 },
+  selectionMeta: { color: '#64748b', fontSize: 12 },
+  inlineActions: { flexDirection: 'row', gap: 8, marginTop: 10 },
+  minorButton: { backgroundColor: '#e2e8f0', borderRadius: 9, paddingHorizontal: 10, paddingVertical: 8 },
+  minorButtonText: { color: '#334155', fontSize: 12, fontWeight: '700' },
+  fileRow: { flexDirection: 'row', alignItems: 'center', gap: 10, backgroundColor: '#f8fafc', borderRadius: 12, padding: 11, marginBottom: 8, borderWidth: 1, borderColor: '#e2e8f0' },
+  fileOrderBadge: { width: 28, height: 28, borderRadius: 9, backgroundColor: '#e0e7ff', alignItems: 'center', justifyContent: 'center' },
+  fileOrderText: { color: '#3730a3', fontWeight: '800', fontSize: 12 },
   fileInfo: { flex: 1, minWidth: 0 },
-  fileName: { color: '#0f172a', fontWeight: '700' },
-  fileMeta: { color: '#64748b', fontSize: 12, marginTop: 3 },
-  removeText: { color: '#dc2626', fontSize: 13, fontWeight: '700', marginLeft: 12 },
-  fieldBlock: { marginTop: 18 },
+  fileName: { color: '#0f172a', fontWeight: '700', fontSize: 13 },
+  fileMeta: { color: '#64748b', fontSize: 11, marginTop: 2 },
+  fileActions: { flexDirection: 'row', alignItems: 'center', gap: 12 },
+  fileActionText: { color: '#334155', fontSize: 18, fontWeight: '800' },
+  removeText: { color: '#dc2626', fontSize: 22, fontWeight: '700' },
+  muted: { opacity: 0.25 },
+  fieldBlock: { marginTop: 12 },
   fieldLabel: { color: '#334155', fontSize: 13, fontWeight: '800', marginBottom: 7 },
-  input: { borderWidth: 1, borderColor: '#cbd5e1', backgroundColor: '#ffffff', color: '#0f172a', borderRadius: 12, paddingHorizontal: 13, paddingVertical: 12, fontSize: 15 },
-  helpText: { color: '#64748b', fontSize: 12, lineHeight: 18, marginTop: 6 },
+  input: { borderWidth: 1, borderColor: '#cbd5e1', backgroundColor: '#ffffff', borderRadius: 11, paddingHorizontal: 13, paddingVertical: 12, color: '#0f172a', fontSize: 14 },
+  helpText: { color: '#64748b', fontSize: 11, lineHeight: 16, marginTop: 6 },
   segmentRow: { flexDirection: 'row', gap: 8, marginTop: 12 },
-  segment: { flex: 1, paddingVertical: 10, alignItems: 'center', borderRadius: 10, backgroundColor: '#f1f5f9', borderWidth: 1, borderColor: '#e2e8f0' },
-  segmentActive: { backgroundColor: '#2563eb', borderColor: '#2563eb' },
-  segmentText: { color: '#475569', fontWeight: '800' },
-  segmentTextActive: { color: '#ffffff' },
-  runButton: { backgroundColor: '#2563eb', borderRadius: 14, paddingVertical: 15, alignItems: 'center', justifyContent: 'center', minHeight: 52, marginTop: 22 },
-  runButtonText: { color: '#ffffff', fontSize: 16, fontWeight: '800' },
+  segment: { flex: 1, borderRadius: 10, paddingVertical: 10, alignItems: 'center', backgroundColor: '#f1f5f9' },
+  segmentActive: { backgroundColor: '#dbeafe', borderWidth: 1, borderColor: '#60a5fa' },
+  segmentText: { color: '#475569', fontWeight: '700' },
+  segmentTextActive: { color: '#1d4ed8' },
+  runButton: { backgroundColor: '#0f172a', borderRadius: 12, paddingVertical: 15, alignItems: 'center', marginTop: 18 },
+  runButtonText: { color: '#ffffff', fontSize: 15, fontWeight: '800' },
   disabled: { opacity: 0.45 },
-  resultCard: { marginTop: 18, padding: 14, borderRadius: 15, backgroundColor: '#f0fdf4', borderWidth: 1, borderColor: '#bbf7d0' },
-  resultBadge: { width: 30, height: 30, borderRadius: 15, backgroundColor: '#16a34a', alignItems: 'center', justifyContent: 'center', marginBottom: 10 },
+  resultCard: { marginTop: 18, borderRadius: 15, padding: 15, backgroundColor: '#f0fdf4', borderWidth: 1, borderColor: '#bbf7d0' },
+  resultBadge: { width: 32, height: 32, borderRadius: 16, backgroundColor: '#16a34a', alignItems: 'center', justifyContent: 'center', marginBottom: 10 },
   resultBadgeText: { color: '#ffffff', fontWeight: '900' },
   resultContent: { marginBottom: 12 },
-  resultTitle: { color: '#166534', fontWeight: '800', fontSize: 15 },
-  resultName: { color: '#14532d', marginTop: 4, fontWeight: '600' },
-  resultMeta: { color: '#15803d', fontSize: 12, marginTop: 3 },
-  resultActions: { flexDirection: 'row', gap: 10 },
-  saveButton: { flex: 1, borderWidth: 1, borderColor: '#16a34a', borderRadius: 11, paddingVertical: 11, alignItems: 'center', justifyContent: 'center' },
-  saveButtonText: { color: '#166534', fontWeight: '800' },
-  shareButton: { flex: 1, backgroundColor: '#166534', borderRadius: 11, paddingVertical: 11, alignItems: 'center', justifyContent: 'center' },
-  shareButtonText: { color: '#ffffff', fontWeight: '800' },
+  resultTitle: { color: '#166534', fontSize: 15, fontWeight: '800' },
+  resultName: { color: '#334155', fontSize: 12, marginTop: 4 },
+  resultMeta: { color: '#64748b', fontSize: 11, marginTop: 3 },
+  resultActions: { flexDirection: 'row', gap: 8 },
+  saveButton: { flex: 1, borderRadius: 10, paddingVertical: 11, alignItems: 'center', backgroundColor: '#dcfce7' },
+  saveButtonText: { color: '#166534', fontWeight: '800', fontSize: 12 },
+  shareButton: { flex: 1, borderRadius: 10, paddingVertical: 11, alignItems: 'center', backgroundColor: '#dbeafe' },
+  shareButtonText: { color: '#1d4ed8', fontWeight: '800', fontSize: 12 },
 });

--- a/App.tsx
+++ b/App.tsx
@@ -25,6 +25,7 @@ import {
   watermarkPdf,
 } from './services/pdfEngine';
 import { ImageInput, imagesToPdf } from './services/imageToPdf';
+import { savePdfToChosenFolder } from './services/savePdf';
 
 type ToolId = 'merge' | 'extract' | 'reorder' | 'rotate' | 'watermark' | 'numbers' | 'images';
 
@@ -72,6 +73,7 @@ export default function App() {
   const [startAt, setStartAt] = useState('1');
   const [rotation, setRotation] = useState<90 | 180 | 270>(90);
   const [busy, setBusy] = useState(false);
+  const [saving, setSaving] = useState(false);
   const [result, setResult] = useState<PdfOutput | null>(null);
 
   const selectedTool = useMemo(() => TOOLS.find(item => item.id === tool) ?? null, [tool]);
@@ -189,6 +191,19 @@ export default function App() {
     }
   }
 
+  async function saveResult() {
+    if (!result) return;
+    setSaving(true);
+    try {
+      await savePdfToChosenFolder(result.uri, result.fileName);
+      Alert.alert('Saved', 'The PDF was copied to the folder you selected.');
+    } catch (error) {
+      Alert.alert('Could not save PDF', errorMessage(error));
+    } finally {
+      setSaving(false);
+    }
+  }
+
   async function shareResult() {
     if (!result) return;
     if (!(await Sharing.isAvailableAsync())) {
@@ -197,7 +212,7 @@ export default function App() {
     }
     await Sharing.shareAsync(result.uri, {
       mimeType: 'application/pdf',
-      dialogTitle: 'Save or share PDF',
+      dialogTitle: 'Share PDF',
       UTI: 'com.adobe.pdf',
     });
   }
@@ -341,9 +356,14 @@ export default function App() {
                   <Text style={styles.resultName}>{result.fileName}</Text>
                   <Text style={styles.resultMeta}>{result.pageCount} pages • {formatBytes(result.bytes)}</Text>
                 </View>
-                <Pressable style={styles.shareButton} onPress={shareResult}>
-                  <Text style={styles.shareButtonText}>Save / Share</Text>
-                </Pressable>
+                <View style={styles.resultActions}>
+                  <Pressable style={[styles.saveButton, saving && styles.disabled]} onPress={saveResult} disabled={saving}>
+                    {saving ? <ActivityIndicator color="#166534" size="small" /> : <Text style={styles.saveButtonText}>Save to folder</Text>}
+                  </Pressable>
+                  <Pressable style={styles.shareButton} onPress={shareResult}>
+                    <Text style={styles.shareButtonText}>Share</Text>
+                  </Pressable>
+                </View>
               </View>
             )}
           </View>
@@ -398,6 +418,9 @@ const styles = StyleSheet.create({
   resultTitle: { color: '#166534', fontWeight: '800', fontSize: 15 },
   resultName: { color: '#14532d', marginTop: 4, fontWeight: '600' },
   resultMeta: { color: '#15803d', fontSize: 12, marginTop: 3 },
-  shareButton: { backgroundColor: '#166534', borderRadius: 11, paddingVertical: 11, alignItems: 'center' },
+  resultActions: { flexDirection: 'row', gap: 10 },
+  saveButton: { flex: 1, borderWidth: 1, borderColor: '#16a34a', borderRadius: 11, paddingVertical: 11, alignItems: 'center', justifyContent: 'center' },
+  saveButtonText: { color: '#166534', fontWeight: '800' },
+  shareButton: { flex: 1, backgroundColor: '#166534', borderRadius: 11, paddingVertical: 11, alignItems: 'center', justifyContent: 'center' },
   shareButtonText: { color: '#ffffff', fontWeight: '800' },
 });

--- a/README.md
+++ b/README.md
@@ -1,26 +1,49 @@
-# Pdf (React Native / Expo)
+# PDF Pro Tools
 
-تطبيق ماسح PDF يعمل أوفلاين، مع ضغط صور، مشاركة، وإتاحة الترقية المدفوعة.
+React Native / Expo PDF utility app focused on real offline PDF transformations.
 
-## الأوامر
-- تشغيل محلي: `npm install && npm start`
-- أندرويد: `npm run android` (قد يتطلب `npx expo prebuild --platform android` أول مرة)
-- ويب: `npm run web`
+## Implemented on `feat/pdf-pro-tools`
 
-## البناء والنشر
-1) إن لم يوجد مجلد android/ و ios/:
-   - `npx expo prebuild --platform android`
-2) أندرويد (AAB):
-   - `cd android && ./gradlew bundleRelease`
-   - الناتج: `android/app/build/outputs/bundle/release/app-release.aab`
-3) النشر إلى Google Play: ارفع ملف AAB واضبط بيانات المتجر.
+- Merge multiple PDF files
+- Extract selected pages using expressions such as `1-3,5,8`
+- Reorder every page into a new order
+- Rotate all pages or selected pages by 90/180/270 degrees
+- Add a permanent text watermark to every page
+- Add permanent page numbers
+- Convert multiple images to A4 PDF pages
+- Save/share the generated PDF through the native share sheet
 
-## الربحية
-- الشراء داخل التطبيق عبر RevenueCat (ضع المفاتيح في `app.json > expo.extra`).
-- الإعلانات عبر Google Mobile Ads (مع App IDs التجريبية الافتراضية). استبدلها بمعرّفاتك قبل الإصدار.
+The PDF operations use `pdf-lib`; file IO uses the Expo SDK 54 legacy filesystem entry point required by the installed API version.
 
-## المزايا
-- اختيار صور متعددة
-- ضغط الصور قبل التضمين
-- إنشاء وحفظ ومشاركة PDF
-- إعلان بنر للمستخدمين المجانيين، وترقية لإزالة الإعلانات وفتح الميزات
+## Intentionally not exposed yet
+
+These tools are not shown in the UI until a real implementation is integrated and tested:
+
+- Strong PDF compression of arbitrary existing PDFs
+- Password encryption / protection
+- Password removal
+- PDF to image rendering
+- Full PDF text editing
+- OCR
+
+The project must not ship placeholder buttons for these features.
+
+## Development
+
+```bash
+npm ci
+npx tsc --noEmit
+npx expo start
+```
+
+For an Android native build:
+
+```bash
+npx expo prebuild --platform android
+cd android
+./gradlew assembleRelease
+```
+
+## CI
+
+`.github/workflows/ci.yml` runs `npm ci` and TypeScript validation on pushes and pull requests.

--- a/app.json
+++ b/app.json
@@ -42,5 +42,9 @@
     "web": {
       "favicon": "./assets/favicon.png"
     }
+  },
+  "react-native-google-mobile-ads": {
+    "android_app_id": "ca-app-pub-3940256099942544~3347511713",
+    "ios_app_id": "ca-app-pub-3940256099942544~1458002511"
   }
 }

--- a/app.json
+++ b/app.json
@@ -1,37 +1,34 @@
 {
   "expo": {
     "name": "PDF Pro Tools",
-    "slug": "PdfApp",
-    "version": "1.1.0",
+    "slug": "pdf-pro-tools",
+    "version": "1.2.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
-    "newArchEnabled": true,
+    "newArchEnabled": false,
     "plugins": [
       [
         "expo-image-picker",
         {
           "photosPermission": "Allow PDF Pro Tools to select images you choose for PDF creation.",
-          "cameraPermission": false,
+          "cameraPermission": "Allow PDF Pro Tools to use the camera when you choose Camera to PDF.",
           "microphonePermission": false
         }
       ]
     ],
-    "extra": {
-      "revenuecatAndroidKey": "",
-      "revenuecatIosKey": ""
-    },
     "splash": {
       "image": "./assets/splash-icon.png",
       "resizeMode": "contain",
       "backgroundColor": "#ffffff"
     },
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": true,
+      "bundleIdentifier": "com.codecsverige.pdf"
     },
     "android": {
       "package": "com.codecsverige.pdf",
-      "versionCode": 2,
+      "versionCode": 3,
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"
@@ -42,9 +39,5 @@
     "web": {
       "favicon": "./assets/favicon.png"
     }
-  },
-  "react-native-google-mobile-ads": {
-    "android_app_id": "ca-app-pub-3940256099942544~3347511713",
-    "ios_app_id": "ca-app-pub-3940256099942544~1458002511"
   }
 }

--- a/app.json
+++ b/app.json
@@ -1,13 +1,22 @@
 {
   "expo": {
-    "name": "PdfApp",
+    "name": "PDF Pro Tools",
     "slug": "PdfApp",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
     "newArchEnabled": true,
-    
+    "plugins": [
+      [
+        "expo-image-picker",
+        {
+          "photosPermission": "Allow PDF Pro Tools to select images you choose for PDF creation.",
+          "cameraPermission": false,
+          "microphonePermission": false
+        }
+      ]
+    ],
     "extra": {
       "revenuecatAndroidKey": "",
       "revenuecatIosKey": ""
@@ -22,14 +31,7 @@
     },
     "android": {
       "package": "com.codecsverige.pdf",
-      "versionCode": 1,
-      "googleServicesFile": "",
-      "permissions": [
-        "CAMERA",
-        "READ_MEDIA_IMAGES",
-        "READ_EXTERNAL_STORAGE",
-        "WRITE_EXTERNAL_STORAGE"
-      ],
+      "versionCode": 2,
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"

--- a/components/Paywall.tsx
+++ b/components/Paywall.tsx
@@ -16,32 +16,33 @@ export default function Paywall({ visible, onClose, onPurchased }: Props) {
   useEffect(() => {
     async function loadOfferings() {
       try {
+        if (!Purchases) return;
         const offerings = await Purchases.getOfferings();
         const current = offerings.current;
         const first = current?.availablePackages?.[0];
         setPackageId(first?.identifier ?? null);
-      } catch (e) {
-        // ignore
+      } catch {
+        // Purchase UI is not part of the active PDF tools screen yet.
       }
     }
     if (visible) loadOfferings();
   }, [visible]);
 
   async function purchase() {
-    if (!packageId) {
+    if (!Purchases || !packageId) {
       Alert.alert('غير متاح', 'العرض غير متاح حاليًا.');
       return;
     }
     setLoading(true);
     try {
       const offerings = await Purchases.getOfferings();
-      const pkg = offerings.current?.availablePackages?.find(p => p.identifier === packageId);
+      const pkg = offerings.current?.availablePackages?.find((p: any) => p.identifier === packageId);
       if (!pkg) throw new Error('Package not found');
       const { customerInfo } = await Purchases.purchasePackage(pkg);
       const active = customerInfo?.entitlements?.active ?? {};
       if (active['pro'] || active['premium']) onPurchased();
-    } catch (e: any) {
-      // cancelled or failed
+    } catch {
+      // Cancelled or failed purchase. Billing will be rebuilt after PDF tools are validated.
     } finally {
       setLoading(false);
     }
@@ -52,7 +53,7 @@ export default function Paywall({ visible, onClose, onPurchased }: Props) {
       <View style={styles.overlay}>
         <View style={styles.sheet}>
           <Text style={styles.title}>ترقية إلى الإصدار المحترف</Text>
-          <Text style={styles.desc}>إزالة الإعلانات، صفحات غير محدودة، وضغط أفضل للصور.</Text>
+          <Text style={styles.desc}>إزالة الإعلانات وفتح الميزات المحترفة.</Text>
           <View style={styles.row}>
             <Pressable style={[styles.btn, styles.outline]} onPress={onClose} disabled={loading}>
               <Text style={styles.btnText}>لاحقًا</Text>
@@ -77,4 +78,3 @@ const styles = StyleSheet.create({
   outline: { backgroundColor: '#0000', borderWidth: 1, borderColor: '#2563eb' },
   btnText: { color: '#fff', fontWeight: '700' },
 });
-

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "npx expo start",
     "android": "npx expo run:android",
     "ios": "npx expo run:ios",
-    "web": "npx expo start --web"
+    "web": "npx expo start --web",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "expo": "~54.0.10",
@@ -34,7 +35,10 @@
   "expo": {
     "autolinking": {
       "android": {
-        "exclude": ["react-native-google-mobile-ads"]
+        "exclude": [
+          "react-native-google-mobile-ads",
+          "react-native-purchases"
+        ]
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -31,5 +31,12 @@
     "@types/react": "~19.1.0",
     "typescript": "~5.9.2"
   },
+  "expo": {
+    "autolinking": {
+      "android": {
+        "exclude": ["react-native-google-mobile-ads"]
+      }
+    }
+  },
   "private": true
 }

--- a/scripts/smoke-emulator.sh
+++ b/scripts/smoke-emulator.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mkdir -p release-output
+APK="release-output/PDF-Pro-Tools-1.2.0.apk"
+PACKAGE="com.codecsverige.pdf"
+
+adb devices -l | tee release-output/adb-devices.txt
+adb shell getprop sys.boot_completed | tee release-output/boot-completed.txt
+
+adb install -r "$APK" | tee release-output/install-result.txt
+grep -q 'Success' release-output/install-result.txt
+
+aDB_LOG="release-output/logcat-after-launch.txt"
+adb logcat -c
+adb shell monkey -p "$PACKAGE" -c android.intent.category.LAUNCHER 1 | tee release-output/launch-result.txt
+sleep 12
+
+PID="$(adb shell pidof "$PACKAGE" | tr -d '\r' || true)"
+echo "PID=$PID" | tee release-output/process.txt
+adb shell dumpsys window | grep -E 'mCurrentFocus|mFocusedApp' | tee release-output/window-focus.txt || true
+adb logcat -d -t 2200 > "$aDB_LOG" || true
+
+if [[ -z "$PID" ]]; then
+  grep -Eai 'FATAL EXCEPTION|AndroidRuntime|ReactNativeJS|ReactNative|Hermes|Expo|com\.codecsverige\.pdf|SoLoader|UnsatisfiedLinkError|Unable to start activity' "$aDB_LOG" \
+    | tail -n 800 > release-output/startup-failure.txt || true
+  cat release-output/startup-failure.txt || true
+  exit 1
+fi
+
+if ! grep -q "$PACKAGE" release-output/window-focus.txt; then
+  echo "Package is alive but not focused after launch." | tee release-output/focus-failure.txt
+  exit 1
+fi
+
+adb logcat -d --pid="$PID" -t 900 > release-output/startup-logcat.txt || true
+if grep -Eqi 'FATAL EXCEPTION|AndroidRuntime.*FATAL' release-output/startup-logcat.txt; then
+  cat release-output/startup-logcat.txt
+  exit 1
+fi
+
+echo 'APK_INSTALL=PASS' | tee release-output/validated.txt
+echo 'APP_LAUNCH=PASS' | tee -a release-output/validated.txt
+echo 'PROCESS_ALIVE=PASS' | tee -a release-output/validated.txt

--- a/services/imageToPdf.ts
+++ b/services/imageToPdf.ts
@@ -1,0 +1,88 @@
+import * as FileSystem from 'expo-file-system/legacy';
+import * as ImageManipulator from 'expo-image-manipulator';
+import { PDFDocument, PageSizes } from 'pdf-lib';
+import type { PdfOutput } from './pdfEngine';
+
+export type ImageInput = {
+  uri: string;
+  width?: number;
+  height?: number;
+};
+
+export type ImageToPdfOptions = {
+  margin?: number;
+  jpegQuality?: number;
+  maxImageWidth?: number;
+  pageMode?: 'auto' | 'portrait' | 'landscape';
+};
+
+function fitInside(sourceWidth: number, sourceHeight: number, boxWidth: number, boxHeight: number) {
+  const scale = Math.min(boxWidth / sourceWidth, boxHeight / sourceHeight);
+  return { width: sourceWidth * scale, height: sourceHeight * scale };
+}
+
+function pageSizeFor(width: number, height: number, mode: ImageToPdfOptions['pageMode']): [number, number] {
+  const [a4Width, a4Height] = PageSizes.A4;
+  if (mode === 'portrait') return [a4Width, a4Height];
+  if (mode === 'landscape') return [a4Height, a4Width];
+  return width > height ? [a4Height, a4Width] : [a4Width, a4Height];
+}
+
+export async function imagesToPdf(
+  images: ImageInput[],
+  options: ImageToPdfOptions = {},
+): Promise<PdfOutput> {
+  if (!images.length) throw new Error('Choose at least one image.');
+
+  const margin = options.margin ?? 28;
+  const quality = options.jpegQuality ?? 0.9;
+  const maxImageWidth = options.maxImageWidth ?? 2200;
+  const mode = options.pageMode ?? 'auto';
+  const pdf = await PDFDocument.create();
+
+  for (const image of images) {
+    const actions: ImageManipulator.Action[] = [];
+    if (image.width && image.width > maxImageWidth) {
+      actions.push({ resize: { width: maxImageWidth } });
+    }
+
+    const normalized = await ImageManipulator.manipulateAsync(image.uri, actions, {
+      compress: quality,
+      format: ImageManipulator.SaveFormat.JPEG,
+      base64: true,
+    });
+    if (!normalized.base64) throw new Error('Could not read one of the selected images.');
+
+    const embedded = await pdf.embedJpg(normalized.base64);
+    const [pageWidth, pageHeight] = pageSizeFor(embedded.width, embedded.height, mode);
+    const page = pdf.addPage([pageWidth, pageHeight]);
+    const fitted = fitInside(
+      embedded.width,
+      embedded.height,
+      pageWidth - margin * 2,
+      pageHeight - margin * 2,
+    );
+
+    page.drawImage(embedded, {
+      x: (pageWidth - fitted.width) / 2,
+      y: (pageHeight - fitted.height) / 2,
+      width: fitted.width,
+      height: fitted.height,
+    });
+  }
+
+  const fileName = `images_${Date.now()}.pdf`;
+  const uri = `${FileSystem.cacheDirectory}${fileName}`;
+  const base64 = await pdf.saveAsBase64({ dataUri: false });
+  await FileSystem.writeAsStringAsync(uri, base64, {
+    encoding: FileSystem.EncodingType.Base64,
+  });
+  const info = await FileSystem.getInfoAsync(uri);
+
+  return {
+    uri,
+    fileName,
+    pageCount: pdf.getPageCount(),
+    bytes: info.exists && typeof info.size === 'number' ? info.size : 0,
+  };
+}

--- a/services/imageToPdf.ts
+++ b/services/imageToPdf.ts
@@ -16,6 +16,11 @@ export type ImageToPdfOptions = {
   pageMode?: 'auto' | 'portrait' | 'landscape';
 };
 
+function decodedBase64Size(base64: string) {
+  const padding = base64.endsWith('==') ? 2 : base64.endsWith('=') ? 1 : 0;
+  return Math.max(0, Math.floor((base64.length * 3) / 4) - padding);
+}
+
 function fitInside(sourceWidth: number, sourceHeight: number, boxWidth: number, boxHeight: number) {
   const scale = Math.min(boxWidth / sourceWidth, boxHeight / sourceHeight);
   return { width: sourceWidth * scale, height: sourceHeight * scale };
@@ -33,12 +38,13 @@ export async function imagesToPdf(
   options: ImageToPdfOptions = {},
 ): Promise<PdfOutput> {
   if (!images.length) throw new Error('Choose at least one image.');
+  if (!FileSystem.cacheDirectory) throw new Error('App cache directory is unavailable.');
 
-  const margin = options.margin ?? 28;
-  const quality = options.jpegQuality ?? 0.9;
-  const maxImageWidth = options.maxImageWidth ?? 2200;
+  const margin = Math.max(0, options.margin ?? 28);
+  const quality = Math.max(0.2, Math.min(1, options.jpegQuality ?? 0.9));
+  const maxImageWidth = Math.max(600, options.maxImageWidth ?? 2200);
   const mode = options.pageMode ?? 'auto';
-  const pdf = await PDFDocument.create();
+  const pdf = await PDFDocument.create({ updateMetadata: false });
 
   for (const image of images) {
     const actions: ImageManipulator.Action[] = [];
@@ -73,16 +79,15 @@ export async function imagesToPdf(
 
   const fileName = `images_${Date.now()}.pdf`;
   const uri = `${FileSystem.cacheDirectory}${fileName}`;
-  const base64 = await pdf.saveAsBase64({ dataUri: false });
+  const base64 = await pdf.saveAsBase64({ dataUri: false, useObjectStreams: true });
   await FileSystem.writeAsStringAsync(uri, base64, {
     encoding: FileSystem.EncodingType.Base64,
   });
-  const info = await FileSystem.getInfoAsync(uri);
 
   return {
     uri,
     fileName,
     pageCount: pdf.getPageCount(),
-    bytes: info.exists && typeof info.size === 'number' ? info.size : 0,
+    bytes: decodedBase64Size(base64),
   };
 }

--- a/services/pdfEngine.ts
+++ b/services/pdfEngine.ts
@@ -17,17 +17,28 @@ async function loadPdf(uri: string) {
   const base64 = await FileSystem.readAsStringAsync(uri, {
     encoding: FileSystem.EncodingType.Base64,
   });
-  return PDFDocument.load(base64, { updateMetadata: false });
+  try {
+    return await PDFDocument.load(base64, { updateMetadata: false });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : '';
+    if (/encrypt/i.test(message)) {
+      throw new Error('This PDF is password protected. Unlock it first, then try again.');
+    }
+    throw new Error(message || 'This PDF could not be opened.');
+  }
 }
 
 async function persistPdf(pdf: PDFDocument, prefix: string): Promise<PdfOutput> {
   if (!FileSystem.cacheDirectory) throw new Error('App cache directory is unavailable.');
+  if (pdf.getPageCount() < 1) throw new Error('A PDF must contain at least one page.');
+
   const fileName = `${prefix}_${Date.now()}.pdf`;
   const uri = `${FileSystem.cacheDirectory}${fileName}`;
   const base64 = await pdf.saveAsBase64({ dataUri: false, useObjectStreams: true });
   await FileSystem.writeAsStringAsync(uri, base64, {
     encoding: FileSystem.EncodingType.Base64,
   });
+
   return {
     uri,
     fileName,
@@ -70,11 +81,13 @@ export function parsePageSelection(expression: string, maxPages: number): number
 export async function mergePdfs(uris: string[]): Promise<PdfOutput> {
   if (uris.length < 2) throw new Error('Choose at least two PDF files.');
   const output = await PDFDocument.create({ updateMetadata: false });
+
   for (const uri of uris) {
     const source = await loadPdf(uri);
     const pages = await output.copyPages(source, source.getPageIndices());
     pages.forEach(page => output.addPage(page));
   }
+
   return persistPdf(output, 'merged');
 }
 
@@ -87,13 +100,29 @@ export async function extractPages(uri: string, expression: string): Promise<Pdf
   return persistPdf(output, 'extracted');
 }
 
+export async function deletePages(uri: string, expression: string): Promise<PdfOutput> {
+  const source = await loadPdf(uri);
+  const total = source.getPageCount();
+  const toDelete = new Set(parsePageSelection(expression, total));
+  const keep = source.getPageIndices().filter(index => !toDelete.has(index));
+
+  if (!keep.length) throw new Error('You cannot delete every page in the PDF.');
+
+  const output = await PDFDocument.create({ updateMetadata: false });
+  const pages = await output.copyPages(source, keep);
+  pages.forEach(page => output.addPage(page));
+  return persistPdf(output, 'pages_removed');
+}
+
 export async function reorderPages(uri: string, expression: string): Promise<PdfOutput> {
   const source = await loadPdf(uri);
   const total = source.getPageCount();
   const indices = parsePageSelection(expression, total);
+
   if (indices.length !== total || new Set(indices).size !== total) {
     throw new Error(`Use every page exactly once. This file has ${total} pages.`);
   }
+
   const output = await PDFDocument.create({ updateMetadata: false });
   const pages = await output.copyPages(source, indices);
   pages.forEach(page => output.addPage(page));
@@ -106,16 +135,19 @@ export async function rotatePages(uri: string, expression = '', delta: 90 | 180 
   const indices = expression.trim()
     ? parsePageSelection(expression, total)
     : Array.from({ length: total }, (_, index) => index);
+
   for (const index of new Set(indices)) {
     const page = pdf.getPage(index);
     page.setRotation(degrees(((page.getRotation().angle || 0) + delta) % 360));
   }
+
   return persistPdf(pdf, 'rotated');
 }
 
 export async function addPageNumbers(uri: string, startAt = 1) {
   const pdf = await loadPdf(uri);
   const font = await pdf.embedFont(StandardFonts.Helvetica);
+
   pdf.getPages().forEach((page, index) => {
     const text = String(startAt + index);
     const size = 10;
@@ -128,14 +160,17 @@ export async function addPageNumbers(uri: string, startAt = 1) {
       color: rgb(0.25, 0.25, 0.25),
     });
   });
+
   return persistPdf(pdf, 'numbered');
 }
 
 export async function watermarkPdf(uri: string, watermark: string) {
   const text = watermark.trim();
   if (!text) throw new Error('Enter watermark text.');
+
   const pdf = await loadPdf(uri);
   const font = await pdf.embedFont(StandardFonts.HelveticaBold);
+
   for (const page of pdf.getPages()) {
     const size = Math.max(24, Math.min(52, page.getWidth() / 9));
     let textWidth = 0;
@@ -144,6 +179,7 @@ export async function watermarkPdf(uri: string, watermark: string) {
     } catch {
       throw new Error('Text watermark currently supports Latin characters only.');
     }
+
     page.drawText(text, {
       x: Math.max(20, (page.getWidth() - textWidth * 0.7) / 2),
       y: page.getHeight() / 2,
@@ -154,5 +190,6 @@ export async function watermarkPdf(uri: string, watermark: string) {
       rotate: degrees(35),
     });
   }
+
   return persistPdf(pdf, 'watermarked');
 }

--- a/services/pdfEngine.ts
+++ b/services/pdfEngine.ts
@@ -1,0 +1,153 @@
+import * as FileSystem from 'expo-file-system/legacy';
+import { degrees, PDFDocument, rgb, StandardFonts } from 'pdf-lib';
+
+export type PdfOutput = {
+  uri: string;
+  fileName: string;
+  pageCount: number;
+  bytes: number;
+};
+
+async function loadPdf(uri: string) {
+  const base64 = await FileSystem.readAsStringAsync(uri, {
+    encoding: FileSystem.EncodingType.Base64,
+  });
+  return PDFDocument.load(base64, { updateMetadata: false });
+}
+
+async function persistPdf(pdf: PDFDocument, prefix: string): Promise<PdfOutput> {
+  const fileName = `${prefix}_${Date.now()}.pdf`;
+  const uri = `${FileSystem.cacheDirectory}${fileName}`;
+  const base64 = await pdf.saveAsBase64({ dataUri: false });
+  await FileSystem.writeAsStringAsync(uri, base64, {
+    encoding: FileSystem.EncodingType.Base64,
+  });
+  const info = await FileSystem.getInfoAsync(uri);
+  return {
+    uri,
+    fileName,
+    pageCount: pdf.getPageCount(),
+    bytes: info.exists && typeof info.size === 'number' ? info.size : 0,
+  };
+}
+
+export async function getPdfPageCount(uri: string) {
+  return (await loadPdf(uri)).getPageCount();
+}
+
+export function parsePageSelection(expression: string, maxPages: number): number[] {
+  const source = expression.replace(/\s+/g, '');
+  if (!source) throw new Error('Enter pages, for example 1-3,5.');
+  const result: number[] = [];
+
+  for (const token of source.split(',')) {
+    const range = token.match(/^(\d+)-(\d+)$/);
+    if (range) {
+      const start = Number(range[1]);
+      const end = Number(range[2]);
+      const step = start <= end ? 1 : -1;
+      for (let value = start; value !== end + step; value += step) {
+        if (value < 1 || value > maxPages) throw new Error(`Page ${value} is outside 1-${maxPages}.`);
+        result.push(value - 1);
+      }
+    } else {
+      if (!/^\d+$/.test(token)) throw new Error(`Invalid page expression: ${token}`);
+      const value = Number(token);
+      if (value < 1 || value > maxPages) throw new Error(`Page ${value} is outside 1-${maxPages}.`);
+      result.push(value - 1);
+    }
+  }
+
+  if (!result.length) throw new Error('No valid pages selected.');
+  return result;
+}
+
+export async function mergePdfs(uris: string[]): Promise<PdfOutput> {
+  if (uris.length < 2) throw new Error('Choose at least two PDF files.');
+  const output = await PDFDocument.create();
+  for (const uri of uris) {
+    const source = await loadPdf(uri);
+    const pages = await output.copyPages(source, source.getPageIndices());
+    pages.forEach(page => output.addPage(page));
+  }
+  return persistPdf(output, 'merged');
+}
+
+export async function extractPages(uri: string, expression: string): Promise<PdfOutput> {
+  const source = await loadPdf(uri);
+  const indices = parsePageSelection(expression, source.getPageCount());
+  const output = await PDFDocument.create();
+  const pages = await output.copyPages(source, indices);
+  pages.forEach(page => output.addPage(page));
+  return persistPdf(output, 'extracted');
+}
+
+export async function reorderPages(uri: string, expression: string): Promise<PdfOutput> {
+  const source = await loadPdf(uri);
+  const total = source.getPageCount();
+  const indices = parsePageSelection(expression, total);
+  if (indices.length !== total || new Set(indices).size !== total) {
+    throw new Error(`Use every page exactly once. This file has ${total} pages.`);
+  }
+  const output = await PDFDocument.create();
+  const pages = await output.copyPages(source, indices);
+  pages.forEach(page => output.addPage(page));
+  return persistPdf(output, 'reordered');
+}
+
+export async function rotatePages(uri: string, expression = '', delta: 90 | 180 | 270 = 90) {
+  const pdf = await loadPdf(uri);
+  const total = pdf.getPageCount();
+  const indices = expression.trim()
+    ? parsePageSelection(expression, total)
+    : Array.from({ length: total }, (_, index) => index);
+  for (const index of new Set(indices)) {
+    const page = pdf.getPage(index);
+    page.setRotation(degrees(((page.getRotation().angle || 0) + delta) % 360));
+  }
+  return persistPdf(pdf, 'rotated');
+}
+
+export async function addPageNumbers(uri: string, startAt = 1) {
+  const pdf = await loadPdf(uri);
+  const font = await pdf.embedFont(StandardFonts.Helvetica);
+  pdf.getPages().forEach((page, index) => {
+    const text = String(startAt + index);
+    const size = 10;
+    const width = font.widthOfTextAtSize(text, size);
+    page.drawText(text, {
+      x: (page.getWidth() - width) / 2,
+      y: 18,
+      size,
+      font,
+      color: rgb(0.25, 0.25, 0.25),
+    });
+  });
+  return persistPdf(pdf, 'numbered');
+}
+
+export async function watermarkPdf(uri: string, watermark: string) {
+  const text = watermark.trim();
+  if (!text) throw new Error('Enter watermark text.');
+  const pdf = await loadPdf(uri);
+  const font = await pdf.embedFont(StandardFonts.HelveticaBold);
+  for (const page of pdf.getPages()) {
+    const size = Math.max(24, Math.min(52, page.getWidth() / 9));
+    let textWidth = 0;
+    try {
+      textWidth = font.widthOfTextAtSize(text, size);
+    } catch {
+      throw new Error('Text watermark currently supports Latin characters only.');
+    }
+    page.drawText(text, {
+      x: Math.max(20, (page.getWidth() - textWidth * 0.7) / 2),
+      y: page.getHeight() / 2,
+      size,
+      font,
+      color: rgb(0.2, 0.2, 0.2),
+      opacity: 0.18,
+      rotate: degrees(35),
+    });
+  }
+  return persistPdf(pdf, 'watermarked');
+}

--- a/services/pdfEngine.ts
+++ b/services/pdfEngine.ts
@@ -8,6 +8,11 @@ export type PdfOutput = {
   bytes: number;
 };
 
+function decodedBase64Size(base64: string) {
+  const padding = base64.endsWith('==') ? 2 : base64.endsWith('=') ? 1 : 0;
+  return Math.max(0, Math.floor((base64.length * 3) / 4) - padding);
+}
+
 async function loadPdf(uri: string) {
   const base64 = await FileSystem.readAsStringAsync(uri, {
     encoding: FileSystem.EncodingType.Base64,
@@ -16,18 +21,18 @@ async function loadPdf(uri: string) {
 }
 
 async function persistPdf(pdf: PDFDocument, prefix: string): Promise<PdfOutput> {
+  if (!FileSystem.cacheDirectory) throw new Error('App cache directory is unavailable.');
   const fileName = `${prefix}_${Date.now()}.pdf`;
   const uri = `${FileSystem.cacheDirectory}${fileName}`;
-  const base64 = await pdf.saveAsBase64({ dataUri: false });
+  const base64 = await pdf.saveAsBase64({ dataUri: false, useObjectStreams: true });
   await FileSystem.writeAsStringAsync(uri, base64, {
     encoding: FileSystem.EncodingType.Base64,
   });
-  const info = await FileSystem.getInfoAsync(uri);
   return {
     uri,
     fileName,
     pageCount: pdf.getPageCount(),
-    bytes: info.exists && typeof info.size === 'number' ? info.size : 0,
+    bytes: decodedBase64Size(base64),
   };
 }
 
@@ -64,7 +69,7 @@ export function parsePageSelection(expression: string, maxPages: number): number
 
 export async function mergePdfs(uris: string[]): Promise<PdfOutput> {
   if (uris.length < 2) throw new Error('Choose at least two PDF files.');
-  const output = await PDFDocument.create();
+  const output = await PDFDocument.create({ updateMetadata: false });
   for (const uri of uris) {
     const source = await loadPdf(uri);
     const pages = await output.copyPages(source, source.getPageIndices());
@@ -76,7 +81,7 @@ export async function mergePdfs(uris: string[]): Promise<PdfOutput> {
 export async function extractPages(uri: string, expression: string): Promise<PdfOutput> {
   const source = await loadPdf(uri);
   const indices = parsePageSelection(expression, source.getPageCount());
-  const output = await PDFDocument.create();
+  const output = await PDFDocument.create({ updateMetadata: false });
   const pages = await output.copyPages(source, indices);
   pages.forEach(page => output.addPage(page));
   return persistPdf(output, 'extracted');
@@ -89,7 +94,7 @@ export async function reorderPages(uri: string, expression: string): Promise<Pdf
   if (indices.length !== total || new Set(indices).size !== total) {
     throw new Error(`Use every page exactly once. This file has ${total} pages.`);
   }
-  const output = await PDFDocument.create();
+  const output = await PDFDocument.create({ updateMetadata: false });
   const pages = await output.copyPages(source, indices);
   pages.forEach(page => output.addPage(page));
   return persistPdf(output, 'reordered');

--- a/services/savePdf.ts
+++ b/services/savePdf.ts
@@ -1,0 +1,17 @@
+import { Directory, File } from 'expo-file-system';
+
+/**
+ * Opens the native folder picker and copies a generated local PDF into
+ * the directory selected by the user. Returns the destination URI.
+ */
+export async function savePdfToChosenFolder(sourceUri: string, fileName: string) {
+  if (!sourceUri || !fileName) throw new Error('The generated PDF is missing.');
+
+  const source = new File(sourceUri);
+  if (!source.exists) throw new Error('The generated PDF no longer exists in app cache.');
+
+  const directory = await Directory.pickDirectoryAsync();
+  const destination = directory.createFile(fileName, 'application/pdf');
+  source.copy(destination);
+  return destination.uri;
+}


### PR DESCRIPTION
## What changed
- Replaced the placeholder scanner screen with a focused PDF tools workspace.
- Added real offline PDF operations: merge, extract pages, delete pages, reorder, rotate, watermark, page numbering, images-to-PDF, and camera-to-PDF.
- Added save-to-folder and share flows for generated PDFs.
- Added clear error handling for unsupported/password-protected input PDFs.
- Kept OCR, password removal, compression, and full text editing hidden rather than shipping fake tools.
- Hardened Android app config for PDF Pro Tools 1.2.0 (`com.codecsverige.pdf`, versionCode 3).
- Added TypeScript CI plus a real Android APK validation workflow.

## Android validation
The workflow builds a standalone release APK, verifies its signature/archive/package/version and ARM64 payload, installs it on an Android API 29 emulator, launches it through the launcher, checks that the app process stays alive, checks window focus, and rejects fatal startup exceptions.

Latest validation for head `6429fe5b227411696db3f8a3dd7e7744ac7d4ce7`: PASS (build, APK integrity, install, launch, process alive).