### PR TITLE
Emergency backup artifact

### DIFF
--- a/.github/workflows/emergency-backup.yml
+++ b/.github/workflows/emergency-backup.yml
@@ -1,0 +1,27 @@
+name: Emergency source backup
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  backup:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Pdf-source-backup-2026-08-19
+          path: |
+            .
+            !.git/**
+            !node_modules/**
+            !.next/**
+          include-hidden-files: true
+          if-no-files-found: error
+          compression-level: 6
+          retention-days: 7


### PR DESCRIPTION
Temporary pull request used only to generate a downloadable source backup artifact. Do not merge.